### PR TITLE
Milestone 3 — DevSecOps & Observability (v0.6.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,14 @@ BINARY_NAME=hedioum-tunnel
 MAIN_PATH=./cmd/hedioum
 BUILD_DIR=bin
 
+# Build metadata injected into the binary for `hedioum-tunnel version`.
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+DATE   ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
 # Linker flags:
-# -s disables symbol table
-# -w disables DWARF generation
-# These reduce binary size by ~50% without affecting runtime functionality.
-LDFLAGS=-ldflags="-s -w"
+# -s disables symbol table, -w disables DWARF generation (~50% smaller binary).
+# -X injects build metadata (Version stays the AppVersion const used by self-update).
+LDFLAGS=-ldflags="-s -w -X main.Commit=$(COMMIT) -X main.Date=$(DATE)"
 
 .PHONY: all build-linux build-linux-arm64 clean fmt deps
 

--- a/README.md
+++ b/README.md
@@ -19,25 +19,32 @@ Hedioum Pool Tunnel is a high-performance, enterprise-grade connection multiplex
 2. **Hedioum Hub (Iran):** Receives the SOCKS5 payload, evaluates pool health, and multiplexes the stream (via HashiCorp Yamux) over an authenticated, encrypted physical connection pool using the Chaos Mesh algorithm.
 3. **Hedioum Egress (Foreign):** Authenticates the Hub via the AEAD handshake (unauthenticated probes go to the SSH decoy), enforces SSRF protections (resolve-once, blocks private/link-local/CGNAT), extracts target metadata, and dials the open internet over forced IPv4 sockets.
 
-## 🚀 Installation & Seamless Updates
+## 🚀 Installation & Updates
 
-You can deploy the Hedioum daemon on any Ubuntu/Debian server using our 1-click installation script. The script automatically fetches the latest compiled release from GitHub and preserves your configuration across updates.
+The binary is self-sufficient: it installs its own systemd service, opens the
+firewall, and manages its config — so `install.sh` is just a thin bootstrap
+(detect architecture → download → run the binary). See **[docs/DEPLOY.md](docs/DEPLOY.md)** for the full guide, including non-interactive (Ansible-friendly) setup and the GitHub-blocked path.
 
-**Installation Order:** You MUST install the Foreign Node first to generate the Authentication Token required by the Iran Node.
+**Installation Order:** install the **Foreign (egress)** node first to generate the auth token the Iran node needs.
 
-### Step 1: Deploy Foreign Node (Egress)
-Run the following command on your foreign VPS:
-
-    bash <(curl -s https://raw.githubusercontent.com/hedioum/Hedioum-Pool-Tunnel/main/install.sh)
-
-Follow the interactive wizard. Copy the generated Auth Token.
-
-### Step 2: Deploy Iran Node (Hub)
-Run the same command on your Iran VPS:
+### One-line bootstrap (GitHub reachable)
+Run on each VPS (foreign first):
 
     bash <(curl -s https://raw.githubusercontent.com/hedioum/Hedioum-Pool-Tunnel/main/install.sh)
 
-Select "Iran Node" and add your Foreign Node. You will be prompted to define your DPI evasion parameters (Bandwidth Limits & Jitter) during setup.
+### Manual (GitHub blocked)
+Copy the matching binary (`hedioum-tunnel` / `hedioum-tunnel-arm64`) to the server, then:
+
+    chmod +x hedioum-tunnel && ./hedioum-tunnel install && hedioum-tunnel
+
+### Non-interactive (automation)
+
+    hedioum-tunnel install
+    hedioum-tunnel setup-foreign --move-ssh        # foreign; prints the token
+    hedioum-tunnel setup-iran --alias DE-01 --target <IP>:22 --socks-port 40001 --token <hex>
+    systemctl start hedioum.service
+
+Updates are rollback-safe (`hedioum-tunnel update`, or `update --file <path>` when GitHub is blocked).
 
 ## ⚙️ Management Dashboard
 

--- a/cmd/hedioum/cli.go
+++ b/cmd/hedioum/cli.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// runSubcommand dispatches a non-flag first argument to a management command.
+// The no-argument invocation (dashboard on a TTY / daemon under systemd) is
+// handled by main() and never reaches here.
+func runSubcommand(name string, args []string) {
+	switch name {
+	case "version":
+		printVersion()
+	case "setup-foreign":
+		cmdSetupForeign(args)
+	case "setup-iran":
+		cmdSetupIran(args)
+	case "add-node":
+		cmdAddNode(args)
+	case "remove-node":
+		cmdRemoveNode(args)
+	case "install":
+		cmdInstall(args)
+	case "uninstall":
+		cmdUninstall(args)
+	case "help", "-h", "--help":
+		printUsage()
+	default:
+		color.Red("[x] Unknown command %q", name)
+		printUsage()
+		os.Exit(2)
+	}
+}
+
+func printUsage() {
+	fmt.Print(`Hedioum Dynamic Pool Tunnel
+
+Usage:
+  hedioum-tunnel                      Interactive dashboard (TTY) or daemon (systemd)
+  hedioum-tunnel version              Print version and build info
+  hedioum-tunnel install              Install/enable the systemd service (self-copy)
+  hedioum-tunnel uninstall [--yes]    Stop, disable, and remove everything
+
+  hedioum-tunnel setup-foreign [flags]   Write the foreign (egress) config
+      --listen-port N (default 22)  --decoy-port N (default 2022)
+      --egress-mode ipv4|ipv6|dual  --egress-bind-ip IP  --move-ssh  --token HEX
+
+  hedioum-tunnel setup-iran   [flags]    Write the Iran (hub) config with one node
+  hedioum-tunnel add-node     [flags]    Append a foreign node to the hub config
+      --alias NAME  --target HOST:PORT  --socks-port N  --token HEX
+      [--min N --max N --bw N --jitter N]
+  hedioum-tunnel remove-node --alias NAME
+
+Flags for the default mode:
+  --reset            Wipe the config and re-run the setup wizard
+  --open-firewall    Open the listen port on the host firewall and exit
+`)
+}
+
+// --- validation helpers (shared with the wizard) ---
+
+func validPort(p int) error {
+	if p < 1 || p > 65535 {
+		return fmt.Errorf("port %d out of range (1..65535)", p)
+	}
+	return nil
+}
+
+func validIP(s string) error {
+	if net.ParseIP(s) == nil {
+		return fmt.Errorf("invalid IP address %q", s)
+	}
+	return nil
+}
+
+// validTarget checks a HOST:PORT where HOST is an IPv4/IPv6 literal or hostname.
+func validTarget(s string) error {
+	host, portStr, err := net.SplitHostPort(s)
+	if err != nil {
+		return fmt.Errorf("target must be HOST:PORT: %w", err)
+	}
+	if host == "" {
+		return fmt.Errorf("target host is empty")
+	}
+	if net.ParseIP(host) == nil && strings.ContainsAny(host, " \t/\\") {
+		return fmt.Errorf("invalid target host %q", host)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return fmt.Errorf("invalid target port %q", portStr)
+	}
+	return validPort(port)
+}
+
+// validToken requires a non-trivial hex string (the tokens we generate are 32 hex).
+func validToken(s string) error {
+	if len(s) < 8 {
+		return fmt.Errorf("token too short (need >= 8 chars)")
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return fmt.Errorf("token must be hexadecimal")
+		}
+	}
+	return nil
+}
+
+// fail prints an error and exits non-zero (for CLI command handlers).
+func fail(format string, a ...interface{}) {
+	color.Red("[x] "+format, a...)
+	os.Exit(1)
+}

--- a/cmd/hedioum/cli.go
+++ b/cmd/hedioum/cli.go
@@ -29,6 +29,8 @@ func runSubcommand(name string, args []string) {
 		cmdInstall(args)
 	case "uninstall":
 		cmdUninstall(args)
+	case "update":
+		cmdUpdate(args)
 	case "help", "-h", "--help":
 		printUsage()
 	default:
@@ -46,6 +48,7 @@ Usage:
   hedioum-tunnel version              Print version and build info
   hedioum-tunnel install              Install/enable the systemd service (self-copy)
   hedioum-tunnel uninstall [--yes]    Stop, disable, and remove everything
+  hedioum-tunnel update [--file PATH]  Update from GitHub, or from a local binary
 
   hedioum-tunnel setup-foreign [flags]   Write the foreign (egress) config
       --listen-port N (default 22)  --decoy-port N (default 2022)

--- a/cmd/hedioum/cli_test.go
+++ b/cmd/hedioum/cli_test.go
@@ -1,0 +1,53 @@
+package main
+
+import "testing"
+
+func TestValidPort(t *testing.T) {
+	for _, p := range []int{1, 22, 443, 65535} {
+		if err := validPort(p); err != nil {
+			t.Errorf("validPort(%d) unexpected error: %v", p, err)
+		}
+	}
+	for _, p := range []int{0, -1, 65536, 99999} {
+		if err := validPort(p); err == nil {
+			t.Errorf("validPort(%d) should error", p)
+		}
+	}
+}
+
+func TestValidIP(t *testing.T) {
+	for _, s := range []string{"1.2.3.4", "::1", "2001:db8::1"} {
+		if err := validIP(s); err != nil {
+			t.Errorf("validIP(%q): %v", s, err)
+		}
+	}
+	for _, s := range []string{"", "bad", "1.2.3.4.5", "example.com"} {
+		if err := validIP(s); err == nil {
+			t.Errorf("validIP(%q) should error", s)
+		}
+	}
+}
+
+func TestValidTarget(t *testing.T) {
+	for _, s := range []string{"1.2.3.4:443", "[::1]:22", "example.com:80"} {
+		if err := validTarget(s); err != nil {
+			t.Errorf("validTarget(%q): %v", s, err)
+		}
+	}
+	for _, s := range []string{"noport", "1.2.3.4:99999", "host:0", ":443", "1.2.3.4:abc"} {
+		if err := validTarget(s); err == nil {
+			t.Errorf("validTarget(%q) should error", s)
+		}
+	}
+}
+
+func TestValidToken(t *testing.T) {
+	if err := validToken("acb329f4a1e30d0b"); err != nil {
+		t.Errorf("valid hex token rejected: %v", err)
+	}
+	for _, s := range []string{"", "short", "zzzz1234", "not-hex!"} {
+		if err := validToken(s); err == nil {
+			t.Errorf("validToken(%q) should error", s)
+		}
+	}
+}

--- a/cmd/hedioum/hedioum.service.tmpl
+++ b/cmd/hedioum/hedioum.service.tmpl
@@ -1,0 +1,36 @@
+[Unit]
+Description=Hedioum Dynamic Pool Tunnel Daemon
+# Order after ssh so the decoy sshd banner can be mirrored on boot.
+After=network.target ssh.service sshd.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/etc/hedioum
+# Open the listen port on the host firewall BEFORE the sandboxed daemon starts.
+# The '+' runs this step with full privileges (outside the sandbox below), which
+# the firewall edit needs; the long-running daemon itself stays locked down.
+ExecStartPre=+/usr/local/bin/hedioum-tunnel --open-firewall
+ExecStart=/usr/local/bin/hedioum-tunnel
+Restart=always
+RestartSec=5
+LimitNOFILE=1048576
+
+# --- Sandbox hardening ---
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/etc/hedioum
+ProtectHome=true
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectClock=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/cmd/hedioum/install.go
+++ b/cmd/hedioum/install.go
@@ -26,6 +26,12 @@ func cmdInstall(args []string) {
 		fail("install must run as root")
 	}
 
+	// The config/working directory must exist before the (namespaced) service can
+	// start — the hardened unit sets WorkingDirectory + ReadWritePaths to it.
+	if err := os.MkdirAll("/etc/hedioum", 0755); err != nil {
+		fail("cannot create /etc/hedioum: %v", err)
+	}
+
 	self, err := os.Executable()
 	if err != nil {
 		fail("cannot locate the running binary: %v", err)

--- a/cmd/hedioum/install.go
+++ b/cmd/hedioum/install.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	_ "embed"
+	"flag"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/fatih/color"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/sysutil"
+)
+
+//go:embed hedioum.service.tmpl
+var systemdUnit string
+
+const (
+	installBinPath  = "/usr/local/bin/hedioum-tunnel"
+	installUnitPath = "/etc/systemd/system/hedioum.service"
+)
+
+// cmdInstall self-installs the running binary + the systemd unit, with no network
+// access required — deploy by copying the binary to the server and running this.
+func cmdInstall(args []string) {
+	if os.Geteuid() != 0 {
+		fail("install must run as root")
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		fail("cannot locate the running binary: %v", err)
+	}
+
+	// Copy self -> temp -> atomic rename, so replacing a running binary does not
+	// hit "text file busy".
+	if err := copyExecutable(self, installBinPath); err != nil {
+		fail("failed to install binary: %v", err)
+	}
+	color.Green("[✓] Binary installed to %s", installBinPath)
+
+	if err := os.WriteFile(installUnitPath, []byte(systemdUnit), 0644); err != nil {
+		fail("failed to write systemd unit: %v", err)
+	}
+	_ = exec.Command("systemctl", "daemon-reload").Run()
+	_ = exec.Command("systemctl", "enable", "hedioum.service").Run()
+	color.Green("[✓] systemd service installed and enabled.")
+
+	color.HiWhite("\nNext:")
+	color.HiWhite("  Foreign: hedioum-tunnel setup-foreign [--move-ssh]")
+	color.HiWhite("  Iran:    hedioum-tunnel setup-iran --alias ... --target IP:PORT --socks-port N --token HEX")
+	color.HiWhite("  Then:    systemctl start hedioum.service")
+}
+
+func copyExecutable(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := dst + ".new"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, dst) // atomic replace
+}
+
+// cmdUninstall stops, disables, and removes everything (non-interactive with --yes).
+func cmdUninstall(args []string) {
+	fs := flag.NewFlagSet("uninstall", flag.ExitOnError)
+	yes := fs.Bool("yes", false, "confirm removal of the daemon, config, and binary")
+	_ = fs.Parse(args)
+	if !*yes {
+		fail("refusing without --yes (this removes the daemon, config, and binary)")
+	}
+	sysutil.Uninstall() // performs the removal and exits
+}

--- a/cmd/hedioum/install.go
+++ b/cmd/hedioum/install.go
@@ -75,6 +75,19 @@ func copyExecutable(src, dst string) error {
 	return os.Rename(tmp, dst) // atomic replace
 }
 
+// cmdUpdate updates the binary from GitHub, or installs a locally-provided one
+// (--file) when GitHub is blocked. Both use the backup/rollback flow.
+func cmdUpdate(args []string) {
+	fs := flag.NewFlagSet("update", flag.ExitOnError)
+	file := fs.String("file", "", "install from a local binary instead of downloading")
+	_ = fs.Parse(args)
+	if *file != "" {
+		sysutil.UpdateFromFile(*file)
+		return
+	}
+	sysutil.SelfUpdate(AppVersion)
+}
+
 // cmdUninstall stops, disables, and removes everything (non-interactive with --yes).
 func cmdUninstall(args []string) {
 	fs := flag.NewFlagSet("uninstall", flag.ExitOnError)

--- a/cmd/hedioum/main.go
+++ b/cmd/hedioum/main.go
@@ -16,14 +16,14 @@ import (
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/logging"
 )
 
-// AppVersion defines the current build version for the self-updater
-// CRITICAL: This must match the GitHub Release Tag exactly (e.g., v0.5.0)
+// AppVersion defines the current build version for the self-updater.
+// CRITICAL: This must match the GitHub Release Tag exactly (e.g., v0.6.0)
 //
-// v0.5.0 adds UDP (SOCKS5 UDP ASSOCIATE over the tunnel) and opt-in IPv6. It
-// carries a BREAKING wire change (a 1-byte stream type now prefixes every logical
-// stream), on top of v0.4.0's authenticated ChaCha20-Poly1305 transport. Nodes
-// must be updated together: the Iran Hub and the Foreign Egress.
-const AppVersion = "v0.5.0"
+// v0.6.0 is a NON-breaking feature release (wire protocol unchanged from v0.5.0,
+// so v0.5 and v0.6 nodes interoperate): structured slog logging, non-interactive
+// CLI + self-install, configurable decoy/listen ports, buffered banner reads, and
+// a ghp.ci-free, signature-free-but-robust self-update.
+const AppVersion = "v0.6.0"
 
 func main() {
 	// Management subcommands (a non-flag first argument): install, setup-*, etc.

--- a/cmd/hedioum/main.go
+++ b/cmd/hedioum/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -25,6 +26,14 @@ import (
 const AppVersion = "v0.5.0"
 
 func main() {
+	// Management subcommands (a non-flag first argument): install, setup-*, etc.
+	// The no-argument invocation (dashboard on a TTY / daemon under systemd) and
+	// the --reset/--open-firewall flags fall through to the logic below.
+	if len(os.Args) > 1 && !strings.HasPrefix(os.Args[1], "-") {
+		runSubcommand(os.Args[1], os.Args[2:])
+		return
+	}
+
 	resetCfg := flag.Bool("reset", false, "Wipe the current configuration database and restart the setup wizard")
 	openFW := flag.Bool("open-firewall", false, "Open the tunnel's listen port on the host firewall and exit (run privileged, e.g. from systemd ExecStartPre=+)")
 	flag.Parse()

--- a/cmd/hedioum/main.go
+++ b/cmd/hedioum/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"log/slog"
 	"os"
 	"os/exec"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/egress"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/firewall"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/ingress"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/logging"
 )
 
 // AppVersion defines the current build version for the self-updater
@@ -63,13 +65,16 @@ func main() {
 		}
 		runInteractiveDashboard(cfg)
 	} else {
-		// Headless Daemon Execution (Systemd)
+		// Headless Daemon Execution (Systemd): structured logs to journald.
+		logging.Init(false) // level via HEDIOUM_LOG_LEVEL (debug|info|warn|error)
+		slog.Info("hedioum daemon starting", "version", AppVersion, "role", cfg.Role)
 		if cfg.Role == "foreign" {
 			egress.StartForeignDaemon(cfg)
 		} else if cfg.Role == "iran" {
 			ingress.StartIranHub(cfg)
 		} else {
 			// Fail securely if role is corrupted or undefined
+			slog.Error("undefined role in config; refusing to start", "role", cfg.Role)
 			os.Exit(1)
 		}
 	}

--- a/cmd/hedioum/setup_cmd.go
+++ b/cmd/hedioum/setup_cmd.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"os/exec"
+	"strconv"
+
+	"github.com/fatih/color"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/sysutil"
+)
+
+// cmdSetupForeign writes the foreign (egress) configuration non-interactively.
+func cmdSetupForeign(args []string) {
+	fs := flag.NewFlagSet("setup-foreign", flag.ExitOnError)
+	listenPort := fs.Int("listen-port", 22, "public listen port")
+	decoyPort := fs.Int("decoy-port", 2022, "local decoy sshd port")
+	egressMode := fs.String("egress-mode", "ipv4", "egress family: ipv4|ipv6|dual")
+	bindIP := fs.String("egress-bind-ip", "", "optional egress source IP")
+	moveSSH := fs.Bool("move-ssh", false, "relocate OpenSSH to --decoy-port")
+	token := fs.String("token", "", "auth token (generated if empty)")
+	_ = fs.Parse(args)
+
+	if err := validPort(*listenPort); err != nil {
+		fail("--listen-port: %v", err)
+	}
+	if err := validPort(*decoyPort); err != nil {
+		fail("--decoy-port: %v", err)
+	}
+	switch *egressMode {
+	case "ipv4", "ipv6", "dual":
+	default:
+		fail("--egress-mode must be ipv4, ipv6, or dual")
+	}
+	if *bindIP != "" {
+		if err := validIP(*bindIP); err != nil {
+			fail("--egress-bind-ip: %v", err)
+		}
+	}
+	tok := *token
+	if tok == "" {
+		tok = sysutil.GenerateSecureToken()
+	} else if err := validToken(tok); err != nil {
+		fail("--token: %v", err)
+	}
+
+	if *listenPort != 22 {
+		color.Yellow("[!] Listen port %d: the SSH mimic is most convincing on 22; a non-22 port may be easier to fingerprint until port-appropriate mimics land.", *listenPort)
+	}
+	if *moveSSH {
+		if err := sysutil.ChangeSSHPort(strconv.Itoa(*decoyPort)); err != nil {
+			color.Red("[x] Failed to relocate OpenSSH to %d: %v", *decoyPort, err)
+		} else {
+			color.Green("[✓] OpenSSH relocated to %d (decoy).", *decoyPort)
+		}
+	}
+
+	cfg := &config.AppConfig{
+		Role:              "foreign",
+		ForeignListenPort: *listenPort,
+		DecoyPort:         *decoyPort,
+		EgressIPMode:      *egressMode,
+		EgressBindIP:      *bindIP,
+		AuthToken:         tok,
+	}
+	if err := config.SaveConfig(cfg); err != nil {
+		fail("failed to save config: %v", err)
+	}
+	color.Green("[✓] Foreign config written (listen %d, decoy %d, egress %s).", *listenPort, *decoyPort, *egressMode)
+	fmt.Printf("Auth Token: %s\n", tok)
+}
+
+// cmdSetupIran writes the Iran (hub) config with its first node (same flags as add-node).
+func cmdSetupIran(args []string) { cmdAddNode(args) }
+
+// cmdAddNode appends a foreign node to the Iran hub config (creating it if absent).
+func cmdAddNode(args []string) {
+	fs := flag.NewFlagSet("add-node", flag.ExitOnError)
+	alias := fs.String("alias", "", "node alias")
+	target := fs.String("target", "", "foreign egress HOST:PORT")
+	socksPort := fs.Int("socks-port", 0, "local SOCKS5 bind port")
+	token := fs.String("token", "", "auth token from the foreign node")
+	min := fs.Int("min", 10, "min warm-up connections")
+	max := fs.Int("max", 20, "max connections")
+	bw := fs.Int("bw", 8, "per-connection bandwidth cap (Mbps)")
+	jitter := fs.Int("jitter", 2, "bandwidth jitter (Mbps)")
+	_ = fs.Parse(args)
+
+	if *alias == "" {
+		fail("--alias is required")
+	}
+	if err := validTarget(*target); err != nil {
+		fail("--target: %v", err)
+	}
+	if err := validPort(*socksPort); err != nil {
+		fail("--socks-port: %v", err)
+	}
+	if err := validToken(*token); err != nil {
+		fail("--token: %v", err)
+	}
+	host, portStr, _ := net.SplitHostPort(*target)
+	tport, _ := strconv.Atoi(portStr)
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		cfg = &config.AppConfig{Role: "iran"}
+	}
+	if cfg.Role == "" {
+		cfg.Role = "iran"
+	}
+	if cfg.Role != "iran" {
+		fail("existing config role is %q, not iran", cfg.Role)
+	}
+
+	cfg.UpdateForeignNode(config.ForeignNode{
+		Alias:               *alias,
+		TargetIP:            host,
+		TargetPort:          tport,
+		LocalSocksPort:      *socksPort,
+		AuthToken:           *token,
+		MinConnections:      *min,
+		MaxConnections:      *max,
+		BandwidthLimitMbps:  *bw,
+		BandwidthJitterMbps: *jitter,
+	})
+	if err := config.SaveConfig(cfg); err != nil {
+		fail("failed to save config: %v", err)
+	}
+	color.Green("[✓] Node %q added (target %s, socks %d).", *alias, *target, *socksPort)
+	restartDaemon()
+}
+
+// cmdRemoveNode removes a foreign node from the Iran hub config.
+func cmdRemoveNode(args []string) {
+	fs := flag.NewFlagSet("remove-node", flag.ExitOnError)
+	alias := fs.String("alias", "", "node alias to remove")
+	_ = fs.Parse(args)
+
+	if *alias == "" {
+		fail("--alias is required")
+	}
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		fail("failed to load config: %v", err)
+	}
+	if !cfg.RemoveForeignNode(*alias) {
+		fail("node %q not found", *alias)
+	}
+	if err := config.SaveConfig(cfg); err != nil {
+		fail("failed to save config: %v", err)
+	}
+	color.Green("[✓] Node %q removed.", *alias)
+	restartDaemon()
+}
+
+// restartDaemon best-effort applies config changes via systemd.
+func restartDaemon() {
+	if err := exec.Command("systemctl", "restart", "hedioum.service").Run(); err != nil {
+		color.Yellow("[-] Could not restart the daemon automatically; apply changes manually.")
+	}
+}

--- a/cmd/hedioum/version.go
+++ b/cmd/hedioum/version.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Build metadata. Version/Commit/Date default sensibly and are overridable at
+// build time via -ldflags "-X main.Version=... -X main.Commit=... -X main.Date=...".
+var (
+	Version = AppVersion
+	Commit  = "unknown"
+	Date    = "unknown"
+)
+
+func printVersion() {
+	fmt.Printf("hedioum-tunnel %s (commit %s, built %s, %s/%s)\n",
+		Version, Commit, Date, runtime.GOOS, runtime.GOARCH)
+}

--- a/cmd/hedioum/wizard.go
+++ b/cmd/hedioum/wizard.go
@@ -58,21 +58,36 @@ func setupForeignNode(cfg *config.AppConfig) {
 		Default: detectedIP,
 	}, &ip, survey.WithValidator(survey.Required))
 
+	// Public listen port (default 22). A non-22 port helps when outbound :22 is
+	// blocked, but weakens the SSH mimic.
+	var listenPortStr string
+	survey.AskOne(&survey.Input{Message: "Public listen port:", Default: "22"}, &listenPortStr)
+	listenPort := clampPort(listenPortStr, 22)
+	if listenPort != 22 {
+		color.Yellow("[!] Listen port %d: the SSH mimic is most convincing on 22; a non-22 port may be easier to fingerprint.", listenPort)
+	}
+
+	// Decoy sshd port (OpenSSH is relocated here).
+	var decoyPortStr string
+	survey.AskOne(&survey.Input{Message: "Decoy sshd port (OpenSSH is moved here):", Default: "2022"}, &decoyPortStr)
+	decoyPort := clampPort(decoyPortStr, 2022)
+
 	changeSSH := false
 	survey.AskOne(&survey.Confirm{
-		Message: "Move OpenSSH daemon to port 2022 to free Port 22 for DPI Decoy?",
+		Message: fmt.Sprintf("Move OpenSSH to port %d to free port %d for the tunnel/decoy?", decoyPort, listenPort),
 		Default: true,
 	}, &changeSSH)
 
 	if changeSSH {
-		if err := sysutil.ChangeSSHPort("2022"); err != nil {
+		if err := sysutil.ChangeSSHPort(strconv.Itoa(decoyPort)); err != nil {
 			color.Red("[x] OpenSSH port relocation failed: %v", err)
 		} else {
-			color.Green("[✓] OpenSSH shifted to 2022. Decoy port available.")
+			color.Green("[✓] OpenSSH shifted to %d. Decoy port available.", decoyPort)
 		}
 	}
 
-	cfg.ForeignListenPort = 22
+	cfg.ForeignListenPort = listenPort
+	cfg.DecoyPort = decoyPort
 	cfg.AuthToken = sysutil.GenerateSecureToken()
 
 	// IPv6 egress is opt-in (default IPv4-only to avoid leaking the v6 identity).
@@ -220,6 +235,15 @@ func validateHost(val interface{}) error {
 		return fmt.Errorf("not a valid IP or hostname")
 	}
 	return nil
+}
+
+// clampPort parses a port string, returning def if it is empty/invalid/out of range.
+func clampPort(s string, def int) int {
+	p := safeAtoi(s, def)
+	if validPort(p) != nil {
+		return def
+	}
+	return p
 }
 
 // safeAtoi parses strings to integers securely. It falls back to a provided default value

--- a/config/config.go
+++ b/config/config.go
@@ -40,14 +40,18 @@ type ForeignNode struct {
 	AuthToken           string `json:"auth_token"`
 }
 
-// getConfigPath determines the absolute storage destination for configuration persistence.
-// It prioritizes the production environment directory (/etc/hedioum) if accessible,
-// otherwise falling back gracefully to the current working directory.
+// getConfigPath determines the storage destination for the configuration.
+// Production uses /etc/hedioum; when running as root we always use it (SaveConfig
+// creates it) so a fresh install does not accidentally write the config to the
+// current working directory. Non-root dev falls back to the local directory.
 func getConfigPath() string {
 	const prodDir = "/etc/hedioum"
 	const fileName = "hedioum.json"
 
 	if stat, err := os.Stat(prodDir); err == nil && stat.IsDir() {
+		return filepath.Join(prodDir, fileName)
+	}
+	if os.Geteuid() == 0 {
 		return filepath.Join(prodDir, fileName)
 	}
 	return fileName

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,9 @@ type AppConfig struct {
 	// optionally pins the source IP on multi-IP servers.
 	EgressIPMode string `json:"egress_ip_mode,omitempty"`
 	EgressBindIP string `json:"egress_bind_ip,omitempty"`
+	// DecoyPort is the local port the real sshd was relocated to; unauthorized
+	// probes on the public listen port are proxied here. Default 2022.
+	DecoyPort int `json:"decoy_port,omitempty"`
 
 	// Iran Node specific properties
 	ForeignNodes []ForeignNode `json:"foreign_nodes,omitempty"`
@@ -71,6 +74,9 @@ func LoadConfig() (*AppConfig, error) {
 	// Ensures existing deployments won't crash due to missing fields in old JSON configs.
 	if cfg.Role == "foreign" && cfg.EgressIPMode == "" {
 		cfg.EgressIPMode = "ipv4" // default: no IPv6 identity leak
+	}
+	if cfg.Role == "foreign" && cfg.DecoyPort == 0 {
+		cfg.DecoyPort = 2022 // default decoy sshd port
 	}
 	for i := range cfg.ForeignNodes {
 		if cfg.ForeignNodes[i].TargetPort == 0 {

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,93 @@
+# Deploying Hedioum
+
+The binary is fully self-sufficient: it installs its own systemd service, opens
+the firewall, and writes its config. Installing via `install.sh` and running the
+binary by hand are equivalent — the script only detects the architecture,
+downloads the matching release, and runs the binary.
+
+## Install order
+
+> Install the **Foreign (egress)** node first — it prints the auth token the Iran
+> hub needs.
+
+## Option A — one-line bootstrap (GitHub reachable)
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/hedioum/Hedioum-Pool-Tunnel/main/install.sh)
+```
+
+This downloads the right binary, runs `hedioum-tunnel install`, and launches the
+interactive wizard.
+
+## Option B — manual (GitHub blocked)
+
+Download the matching asset (`hedioum-tunnel` or `hedioum-tunnel-arm64`) on any
+machine, copy it to the server, then:
+
+```bash
+chmod +x hedioum-tunnel
+./hedioum-tunnel install      # self-copies to /usr/local/bin + installs the service
+hedioum-tunnel                # interactive setup wizard
+```
+
+## Option C — fully non-interactive (automation / Ansible)
+
+No wizard, no prompts.
+
+**Foreign node:**
+```bash
+./hedioum-tunnel install
+hedioum-tunnel setup-foreign --listen-port 22 --decoy-port 2022 --move-ssh
+#   prints: Auth Token: <hex>
+systemctl start hedioum.service
+```
+
+**Iran hub:**
+```bash
+./hedioum-tunnel install
+hedioum-tunnel setup-iran \
+  --alias DE-01 --target <FOREIGN_IP>:22 --socks-port 40001 --token <hex> \
+  --min 10 --max 20 --bw 8 --jitter 2
+systemctl start hedioum.service
+hedioum-tunnel add-node --alias NL-02 --target <IP>:22 --socks-port 40002 --token <hex>
+hedioum-tunnel remove-node --alias NL-02
+```
+
+## Ports
+
+- `--listen-port` (default **22**): the public tunnel port. A non-22 port helps
+  where outbound :22 is blocked, but weakens the SSH mimic — a warning is shown.
+- `--decoy-port` (default **2022**): where the real `sshd` is relocated; the
+  tunnel routes unauthenticated probes (and real admin SSH) there.
+- `--egress-mode ipv4|ipv6|dual` and `--egress-bind-ip IP` control how the foreign
+  node reaches the internet (default `ipv4`, no IPv6 identity leak).
+
+## Updating
+
+```bash
+hedioum-tunnel update                       # download the latest release + rollback-safe swap
+hedioum-tunnel update --file ./hedioum-tunnel   # install a locally-provided binary (GitHub blocked)
+```
+
+## Logs & debugging
+
+The daemon logs to journald (structured, color-free):
+
+```bash
+journalctl -u hedioum.service -f
+journalctl -u hedioum.service -p warning     # warnings and errors only
+```
+
+Turn on verbose diagnostics (e.g. to see why a connection dropped):
+
+```bash
+systemctl edit hedioum.service   # add:  [Service]\nEnvironment=HEDIOUM_LOG_LEVEL=debug
+systemctl restart hedioum.service
+```
+
+## Management
+
+```bash
+hedioum-tunnel version           # version + build (commit/date)
+hedioum-tunnel uninstall --yes   # stop, disable, and remove everything
+```

--- a/install.sh
+++ b/install.sh
@@ -1,127 +1,51 @@
 #!/bin/bash
-
 # ==========================================================
-# Hedioum Dynamic Pool Tunnel - 1-Click Installer & Updater
+# Hedioum Dynamic Pool Tunnel - minimal bootstrap
+#
+# This script only: (1) checks the CPU architecture, (2) downloads the matching
+# release binary from GitHub, (3) runs it. The BINARY itself does everything else
+# (self-copy to /usr/local/bin, systemd service, firewall, config), so installing
+# via this script and running the binary by hand are equivalent.
 # ==========================================================
+set -euo pipefail
 
-if [ "$EUID" -ne 0 ]; then
-  echo "[x] CRITICAL: Please run the installer as root (e.g., sudo bash install.sh)"
+if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+  echo "[x] Please run as root (e.g. sudo bash install.sh)"
   exit 1
 fi
 
-echo "=================================================="
-echo "  Deploying Hedioum Stealth Mesh Daemon..."
-echo "=================================================="
+case "$(uname -m)" in
+  aarch64 | arm64) ASSET="hedioum-tunnel-arm64" ;;
+  *) ASSET="hedioum-tunnel" ;;
+esac
+echo "[*] Architecture asset: $ASSET"
 
-mkdir -p /etc/hedioum
-mkdir -p /usr/local/bin
+URL="https://github.com/hedioum/Hedioum-Pool-Tunnel/releases/latest/download/${ASSET}"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
 
-# --- Stop service and unlink binary to prevent 'Text file busy' error ---
-if systemctl is-active --quiet hedioum.service; then
-    echo "[*] Stopping existing daemon to apply update..."
-    systemctl stop hedioum.service > /dev/null 2>&1
-fi
-rm -f /usr/local/bin/hedioum-tunnel
+echo "[*] Downloading the latest release from GitHub..."
+ok=""
+for attempt in 1 2 3; do
+  if curl -fL --connect-timeout 15 -o "$TMP" "$URL"; then ok=1; break; fi
+  echo "[-] Attempt $attempt failed; retrying..."
+  sleep 2
+done
 
-# --- Architecture Detection ---
-OS_ARCH=$(uname -m)
-TARGET_ASSET="hedioum-tunnel"
-
-if [ "$OS_ARCH" = "aarch64" ] || [ "$OS_ARCH" = "arm64" ]; then
-    TARGET_ASSET="hedioum-tunnel-arm64"
-    echo "[*] Detected ARM64 architecture."
-else
-    echo "[*] Detected AMD64/x86_64 architecture."
-fi
-
-# --- Dynamic Release Downloader (GitHub API) ---
-echo "[*] Fetching the latest release from GitHub..."
-
-# Match exactly target asset using double quotes to avoid partial matches
-LATEST_URL=$(curl -s https://api.github.com/repos/hedioum/Hedioum-Pool-Tunnel/releases/latest | grep "browser_download_url" | grep "$TARGET_ASSET\"" | cut -d '"' -f 4)
-
-# Fallback URLs in case GitHub API is rate-limited or blocked
-if [ -z "$LATEST_URL" ]; then
-    echo "[-] GitHub API rate-limited or blocked. Falling back to static release link..."
-    FALLBACK_VERSION="v0.5.0"
-    LATEST_URL="https://github.com/hedioum/Hedioum-Pool-Tunnel/releases/download/${FALLBACK_VERSION}/${TARGET_ASSET}"
-fi
-
-URL_PROXY="https://ghp.ci/$LATEST_URL"
-
-if curl -f -L -s -o /usr/local/bin/hedioum-tunnel "$LATEST_URL"; then
-    echo "[✓] Binary downloaded successfully (Direct Release)."
-elif curl -f -L -s -o /usr/local/bin/hedioum-tunnel "$URL_PROXY"; then
-    echo "[✓] Binary downloaded successfully (Proxy Fallback for Iran Hub)."
-else
-    echo "[x] ERROR: Failed to download the binary. Network is severely restricted."
-    echo "    Try running the installer again later, or use a VPN."
-    exit 1
-fi
-
-chmod +x /usr/local/bin/hedioum-tunnel
-
-# --- Configuring Systemd background service ---
-echo "[*] Configuring Systemd background service..."
-cat << 'EOF' > /etc/systemd/system/hedioum.service
-[Unit]
-Description=Hedioum Dynamic Pool Tunnel Daemon
-# Order after ssh so the decoy sshd banner can be mirrored on boot.
-After=network.target ssh.service sshd.service
-
-[Service]
-Type=simple
-User=root
-WorkingDirectory=/etc/hedioum
-# Open the listen port on the host firewall BEFORE the sandboxed daemon starts.
-# The '+' runs this step with full privileges (outside the sandbox below), which
-# the firewall edit needs; the long-running daemon itself stays locked down.
-ExecStartPre=+/usr/local/bin/hedioum-tunnel --open-firewall
-ExecStart=/usr/local/bin/hedioum-tunnel
-Restart=always
-RestartSec=5
-LimitNOFILE=1048576
-
-# --- Sandbox hardening ---
-# The daemon only needs to bind a low port, dial the network + the local decoy,
-# and read /etc/hedioum. It never modifies system files at runtime (config edits
-# happen from the interactive dashboard). Drop every capability except binding a
-# privileged port, and lock down the filesystem/kernel surface.
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-AmbientCapabilities=CAP_NET_BIND_SERVICE
-NoNewPrivileges=true
-ProtectSystem=strict
-ReadWritePaths=/etc/hedioum
-ProtectHome=true
-PrivateTmp=true
-ProtectControlGroups=true
-ProtectKernelModules=true
-ProtectKernelTunables=true
-ProtectClock=true
-RestrictSUIDSGID=true
-RestrictRealtime=true
-LockPersonality=true
-
-[Install]
-WantedBy=multi-user.target
+if [ -z "$ok" ]; then
+  cat <<EOF
+[x] Download failed. GitHub may be blocked on this network.
+    Download '${ASSET}' manually on another machine, copy it to this server, then:
+        chmod +x ${ASSET} && ./${ASSET} install
+    and configure with 'hedioum-tunnel' (wizard) or the setup-* subcommands.
 EOF
-
-systemctl daemon-reload
-systemctl enable hedioum.service > /dev/null 2>&1
-
-echo "=================================================="
-if [ ! -f "/etc/hedioum/hedioum.json" ]; then
-    echo -e "[!] Fresh installation detected. Launching Initial Setup Wizard..."
-    sleep 2
-    cd /etc/hedioum && hedioum-tunnel
-    echo -e "\n[✓] Setup complete! Hedioum Daemon is now running in the background."
-else
-    echo "[✓] Existing configuration found. Applying seamless update..."
-    systemctl restart hedioum.service
-    echo "[✓] Hedioum Daemon updated and restarted gracefully."
+  exit 1
 fi
 
-echo "=================================================="
-echo " [Ops] Management Dashboard Command:"
-echo " Simply type 'hedioum-tunnel' anywhere in your terminal."
-echo "=================================================="
+chmod +x "$TMP"
+
+echo "[*] Installing (the binary sets up the service, firewall, and config paths)..."
+"$TMP" install
+
+echo "[*] Launching interactive setup..."
+exec hedioum-tunnel

--- a/internal/egress/server.go
+++ b/internal/egress/server.go
@@ -9,12 +9,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/hashicorp/yamux"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/mimic"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/securestream"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/tunproto"
+	"log/slog"
 )
 
 const (
@@ -53,12 +53,12 @@ func StartForeignDaemon(cfg *config.AppConfig) {
 
 	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
-		color.Red("[x] CRITICAL: Failed to bind Egress Daemon on %s. Is port %d free? Error: %v", listenAddr, listenPort, err)
+		slog.Error("failed to bind egress daemon", "addr", listenAddr, "port", listenPort, "err", err)
 		return
 	}
 
-	color.Green("[✓] Foreign Egress Daemon actively listening on %s (egress mode: %s)", listenAddr, egressMode)
-	color.Cyan("[i] Real SSH daemon decoy target set to %s", decoySSHPrt)
+	slog.Info("egress daemon listening", "addr", listenAddr, "egress_mode", egressMode)
+	slog.Info("decoy target set", "decoy", decoySSHPrt)
 
 	// Mirror the real sshd banner so a genuine SSH client (password or key) routed
 	// to the decoy still completes key exchange on the public port. Kept fresh so
@@ -92,9 +92,9 @@ func newDecoyBannerMirror(addr string) *decoyBannerMirror {
 	// the banner ready before we accept connections.
 	if b, err := mimic.FetchRealSSHBanner(addr); err == nil && b != "" {
 		m.v.Store(b)
-		color.Cyan("[i] Mirroring decoy SSH banner for transparent admin access.")
+		slog.Info("mirroring decoy SSH banner")
 	} else {
-		color.Yellow("[-] Decoy SSH banner not available yet from %s; retrying in the background (admin SSH via the decoy may fail until then).", addr)
+		slog.Warn("decoy SSH banner not available yet; retrying in background", "decoy", addr)
 	}
 	go m.refreshLoop(addr)
 	return m
@@ -112,7 +112,7 @@ func (m *decoyBannerMirror) refreshLoop(addr string) {
 		time.Sleep(3 * time.Second)
 		if b, err := mimic.FetchRealSSHBanner(addr); err == nil && b != "" {
 			m.v.Store(b)
-			color.Cyan("[i] Mirroring decoy SSH banner for transparent admin access.")
+			slog.Info("mirroring decoy SSH banner")
 			break
 		}
 	}
@@ -139,7 +139,7 @@ func handleIncomingConnection(conn net.Conn, expectedToken string, filter *secur
 		// protocol. Route it to the real OpenSSH decoy so the server is
 		// indistinguishable from an ordinary SSH host (no ban, uniform behavior).
 		if errors.Is(err, securestream.ErrAuth) {
-			color.Yellow("[-] Unauthorized/replayed probe from %s. Routing to Decoy SSH.", clientIP)
+			slog.Debug("unauthorized/replayed probe; routing to decoy", "client_ip", clientIP)
 		}
 		go proxyToDecoy(replayConn)
 		return
@@ -157,7 +157,7 @@ func handleIncomingConnection(conn net.Conn, expectedToken string, filter *secur
 		return
 	}
 
-	color.Green("[+] Authentic connection established from Iran Hub (%s)", clientIP)
+	slog.Info("authentic hub connection established", "client_ip", clientIP)
 
 	// 3. Accept logical streams from the Hub and route them to the open internet
 	go handleYamuxSession(session)
@@ -240,7 +240,7 @@ func handleTCPStream(stream net.Conn) {
 	remoteConn, err := safeDialTarget(targetAddr)
 	if err != nil {
 		if errors.Is(err, errBlockedTarget) {
-			color.Red("[!] Blocked SSRF attempt to %s (%v)", targetAddr, err)
+			slog.Warn("blocked SSRF attempt (TCP)", "target", targetAddr, "err", err)
 		}
 		return
 	}

--- a/internal/egress/server.go
+++ b/internal/egress/server.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"strconv"
 	"sync/atomic"
@@ -14,11 +15,9 @@ import (
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/mimic"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/securestream"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/tunproto"
-	"log/slog"
 )
 
 const (
-	decoySSHPrt = "127.0.0.1:2022"
 	dialTimeout = 10 * time.Second
 
 	egressIPv4 = "ipv4"
@@ -26,11 +25,13 @@ const (
 	egressDual = "dual"
 )
 
-// Egress dial policy, set once at StartForeignDaemon. Default is IPv4-only so a
-// misconfiguration can never leak the server's IPv6 identity.
+// Egress policy, set once at StartForeignDaemon. Defaults are IPv4-only egress
+// (so a misconfiguration can never leak the server's IPv6 identity) and the
+// conventional decoy sshd port 2022.
 var (
 	egressMode   = egressIPv4
 	egressBindIP net.IP // optional source IP to bind
+	decoyAddr    = "127.0.0.1:2022"
 )
 
 // StartForeignDaemon boots up the egress networking processes on the foreign server.
@@ -41,6 +42,9 @@ func StartForeignDaemon(cfg *config.AppConfig) {
 	}
 	if cfg.EgressBindIP != "" {
 		egressBindIP = net.ParseIP(cfg.EgressBindIP)
+	}
+	if cfg.DecoyPort != 0 {
+		decoyAddr = fmt.Sprintf("127.0.0.1:%d", cfg.DecoyPort)
 	}
 
 	// Dynamically bind to the configured port or fallback to 22
@@ -58,12 +62,12 @@ func StartForeignDaemon(cfg *config.AppConfig) {
 	}
 
 	slog.Info("egress daemon listening", "addr", listenAddr, "egress_mode", egressMode)
-	slog.Info("decoy target set", "decoy", decoySSHPrt)
+	slog.Info("decoy target set", "decoy", decoyAddr)
 
 	// Mirror the real sshd banner so a genuine SSH client (password or key) routed
 	// to the decoy still completes key exchange on the public port. Kept fresh so
 	// it survives boot races (sshd not up yet) and sshd upgrades.
-	banner := newDecoyBannerMirror(decoySSHPrt)
+	banner := newDecoyBannerMirror(decoyAddr)
 
 	// Bounded, TTL'd replay protection for the authentication handshake.
 	replayFilter := securestream.NewReplayFilter(0)
@@ -168,7 +172,7 @@ func proxyToDecoy(clientConn net.Conn) {
 	defer clientConn.Close()
 
 	// Dial the real SSH daemon we moved to port 2022
-	decoyConn, err := net.DialTimeout("tcp", decoySSHPrt, 5*time.Second)
+	decoyConn, err := net.DialTimeout("tcp", decoyAddr, 5*time.Second)
 	if err != nil {
 		return
 	}

--- a/internal/egress/udp.go
+++ b/internal/egress/udp.go
@@ -2,12 +2,12 @@ package egress
 
 import (
 	"errors"
+	"log/slog"
 	"net"
 	"sync"
 	"time"
 
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/tunproto"
-	"log/slog"
 )
 
 const (

--- a/internal/egress/udp.go
+++ b/internal/egress/udp.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/tunproto"
+	"log/slog"
 )
 
 const (
@@ -73,7 +73,7 @@ func handleUDPStream(stream net.Conn) {
 			if derr != nil {
 				mu.Unlock()
 				if errors.Is(derr, errBlockedTarget) {
-					color.Red("[!] Blocked UDP SSRF attempt to %s", key)
+					slog.Warn("blocked SSRF attempt (UDP)", "target", key)
 				}
 				continue
 			}

--- a/internal/ingress/hub.go
+++ b/internal/ingress/hub.go
@@ -3,6 +3,7 @@ package ingress
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"math/rand"
 	"net"
 	"strconv"
@@ -13,7 +14,6 @@ import (
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/mimic"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/pool"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/tunproto"
-	"log/slog"
 )
 
 // StartIranHub initializes the SOCKS5 listeners and dynamically scaling connection

--- a/internal/ingress/hub.go
+++ b/internal/ingress/hub.go
@@ -8,12 +8,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/hashicorp/yamux"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/mimic"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/pool"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/tunproto"
+	"log/slog"
 )
 
 // StartIranHub initializes the SOCKS5 listeners and dynamically scaling connection
@@ -101,11 +101,11 @@ func startLocalSocksListener(node config.ForeignNode, hubManager *pool.HubManage
 	listenAddr := fmt.Sprintf("127.0.0.1:%d", node.LocalSocksPort)
 	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
-		color.Red("[x] CRITICAL: Failed to bind SOCKS5 listener for [%s] on %s: %v", node.Alias, listenAddr, err)
+		slog.Error("failed to bind SOCKS5 listener", "node", node.Alias, "addr", listenAddr, "err", err)
 		return
 	}
 
-	color.Green("[✓] SOCKS5 Ingress active for [%s] on %s", node.Alias, listenAddr)
+	slog.Info("SOCKS5 ingress active", "node", node.Alias, "addr", listenAddr)
 
 	for {
 		clientConn, err := listener.Accept()
@@ -125,7 +125,8 @@ func handleClientTraffic(localConn net.Conn, nodeAlias string, hubManager *pool.
 	// 1. Negotiate SOCKS5 and read the request (command + destination).
 	cmd, dst, err := readSocksRequest(localConn)
 	if err != nil {
-		// Silently drop bad requests/scanners to conserve CPU and RAM
+		// Drop bad requests/scanners to conserve CPU and RAM.
+		slog.Debug("socks handshake failed", "node", nodeAlias, "err", err)
 		return
 	}
 
@@ -140,6 +141,7 @@ func handleClientTraffic(localConn net.Conn, nodeAlias string, hubManager *pool.
 	case cmdUDPAssociate:
 		handleUDPAssociate(localConn, nodeAlias, hubManager)
 	default:
+		slog.Debug("unsupported SOCKS command", "node", nodeAlias, "cmd", cmd)
 		_ = sendSocksReply(localConn, repCmdNotSupported, net.IPv4zero, 0)
 	}
 }
@@ -150,6 +152,7 @@ func handleTCPConnect(localConn net.Conn, targetDest, nodeAlias string, hubManag
 	stream, err := hubManager.GetStreamTCP(nodeAlias)
 	if err != nil {
 		// Pool temporarily exhausted or dead: drop; X-UI/Xray core retries.
+		slog.Debug("tcp pool unavailable, dropping connection", "node", nodeAlias, "err", err)
 		return
 	}
 	defer stream.Close()

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,122 @@
+// Package logging configures structured, journald-friendly logging for the
+// daemon side (systemd, no TTY). Output is color-free and machine-readable, and
+// each line is prefixed with a syslog priority (`<6>` info … `<3>` error) so
+// `journalctl -p` filtering works. The interactive TUI (dashboard/wizard) keeps
+// its human-facing color output and does not use this package.
+package logging
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Init installs the daemon slog handler as the default logger. debug forces the
+// Debug level; the HEDIOUM_LOG_LEVEL env var (debug|info|warn|error) overrides.
+func Init(debug bool) {
+	level := slog.LevelInfo
+	if debug {
+		level = slog.LevelDebug
+	}
+	if lv, ok := parseLevel(os.Getenv("HEDIOUM_LOG_LEVEL")); ok {
+		level = lv
+	}
+	slog.SetDefault(slog.New(NewHandler(os.Stderr, level)))
+}
+
+func parseLevel(s string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error":
+		return slog.LevelError, true
+	default:
+		return 0, false
+	}
+}
+
+// handler is a minimal slog.Handler that writes journald-friendly lines:
+//
+//	<pri>LEVEL message key=value key=value
+type handler struct {
+	level slog.Leveler
+	mu    *sync.Mutex
+	w     io.Writer
+	attrs []slog.Attr
+}
+
+// NewHandler builds the daemon log handler writing to w at the given level.
+func NewHandler(w io.Writer, level slog.Leveler) slog.Handler {
+	return &handler{level: level, mu: &sync.Mutex{}, w: w}
+}
+
+func (h *handler) Enabled(_ context.Context, l slog.Level) bool {
+	return l >= h.level.Level()
+}
+
+func (h *handler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	b.WriteString(priorityPrefix(r.Level))
+	b.WriteString(r.Level.String())
+	b.WriteByte(' ')
+	b.WriteString(r.Message)
+	for _, a := range h.attrs {
+		appendAttr(&b, a)
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		appendAttr(&b, a)
+		return true
+	})
+	b.WriteByte('\n')
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, err := io.WriteString(h.w, b.String())
+	return err
+}
+
+func (h *handler) WithAttrs(as []slog.Attr) slog.Handler {
+	if len(as) == 0 {
+		return h
+	}
+	nh := *h
+	nh.attrs = append(append([]slog.Attr(nil), h.attrs...), as...)
+	return &nh
+}
+
+// WithGroup is a no-op: this daemon does not use attribute groups.
+func (h *handler) WithGroup(string) slog.Handler { return h }
+
+func appendAttr(b *strings.Builder, a slog.Attr) {
+	if a.Equal(slog.Attr{}) {
+		return
+	}
+	b.WriteByte(' ')
+	b.WriteString(a.Key)
+	b.WriteByte('=')
+	b.WriteString(a.Value.String())
+}
+
+// priorityPrefix maps a slog level to an sd-daemon syslog priority prefix.
+func priorityPrefix(l slog.Level) string {
+	var p int
+	switch {
+	case l >= slog.LevelError:
+		p = 3 // err
+	case l >= slog.LevelWarn:
+		p = 4 // warning
+	case l >= slog.LevelInfo:
+		p = 6 // info
+	default:
+		p = 7 // debug
+	}
+	return "<" + strconv.Itoa(p) + ">"
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,78 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestHandlerFormatAndPriority(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(NewHandler(&buf, slog.LevelDebug))
+
+	log.Info("hello", "node", "de-01", "count", 3)
+	out := buf.String()
+	if !strings.HasPrefix(out, "<6>INFO hello") {
+		t.Fatalf("info line: %q", out)
+	}
+	if !strings.Contains(out, "node=de-01") || !strings.Contains(out, "count=3") {
+		t.Fatalf("attrs missing: %q", out)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Fatalf("output must be color-free: %q", out)
+	}
+
+	buf.Reset()
+	log.Warn("careful")
+	if !strings.HasPrefix(buf.String(), "<4>WARN") {
+		t.Fatalf("warn priority: %q", buf.String())
+	}
+
+	buf.Reset()
+	log.Error("boom")
+	if !strings.HasPrefix(buf.String(), "<3>ERROR") {
+		t.Fatalf("error priority: %q", buf.String())
+	}
+}
+
+func TestLevelFiltering(t *testing.T) {
+	var buf bytes.Buffer
+	h := NewHandler(&buf, slog.LevelInfo)
+	if h.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("debug should be filtered at info level")
+	}
+	log := slog.New(h)
+	log.Debug("should-not-appear")
+	if buf.Len() != 0 {
+		t.Fatalf("debug leaked: %q", buf.String())
+	}
+	log.Info("visible")
+	if !strings.Contains(buf.String(), "visible") {
+		t.Fatalf("info should appear: %q", buf.String())
+	}
+}
+
+func TestWithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(NewHandler(&buf, slog.LevelInfo)).With("role", "egress")
+	log.Info("up")
+	if !strings.Contains(buf.String(), "role=egress") {
+		t.Fatalf("With attr missing: %q", buf.String())
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	for in, want := range map[string]slog.Level{
+		"debug": slog.LevelDebug, "INFO": slog.LevelInfo,
+		"warn": slog.LevelWarn, "warning": slog.LevelWarn, "error": slog.LevelError,
+	} {
+		if lv, ok := parseLevel(in); !ok || lv != want {
+			t.Errorf("parseLevel(%q) = %v,%v want %v", in, lv, ok, want)
+		}
+	}
+	if _, ok := parseLevel("bogus"); ok {
+		t.Error("bogus level should not parse")
+	}
+}

--- a/internal/mimic/ssh.go
+++ b/internal/mimic/ssh.go
@@ -1,6 +1,7 @@
 package mimic
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -83,9 +84,10 @@ func GetDynamicSSHBanner() string {
 	return defaultSSHBanner
 }
 
-// readBanner safely reads strictly up to the newline character, so it never
-// over-reads into the bytes that follow the banner.
-func readBanner(conn net.Conn) (string, error) {
+// readBannerConn reads strictly byte-by-byte up to the newline, so it never
+// over-reads past the banner. Used on the decoy path, where the bytes after the
+// banner are piped raw and must NOT be swallowed by a buffer.
+func readBannerConn(conn net.Conn) (string, error) {
 	var banner []byte
 	buf := make([]byte, 1)
 	for i := 0; i < 255; i++ {
@@ -99,6 +101,18 @@ func readBanner(conn net.Conn) (string, error) {
 		}
 	}
 	return string(banner), nil
+}
+
+// readBannerBuffered reads the banner from a bufio.Reader. Over-reading past the
+// banner is fine here: any buffered bytes (salt/first frame) stay in br and are
+// consumed by the secure handshake that shares it. The bufio buffer bounds the
+// banner length (a probe sending a huge line yields ErrBufferFull -> decoy).
+func readBannerBuffered(br *bufio.Reader) (string, error) {
+	line, err := br.ReadSlice('\n')
+	if err != nil {
+		return "", err
+	}
+	return string(line), nil
 }
 
 // FetchRealSSHBanner connects to the decoy sshd and returns its exact banner
@@ -115,7 +129,7 @@ func FetchRealSSHBanner(addr string) (string, error) {
 	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
 		return "", err
 	}
-	return readBanner(conn)
+	return readBannerConn(conn)
 }
 
 // ConsumeDecoyServerBanner reads and discards the SSH banner from the decoy so a
@@ -125,7 +139,7 @@ func ConsumeDecoyServerBanner(conn net.Conn) error {
 		return err
 	}
 	defer conn.SetReadDeadline(time.Time{})
-	_, err := readBanner(conn)
+	_, err := readBannerConn(conn)
 	return err
 }
 
@@ -140,16 +154,18 @@ func PerformClientHandshake(conn net.Conn, token string) (net.Conn, error) {
 	}
 	defer conn.SetDeadline(time.Time{})
 
-	// 1. Exchange banners (camouflage layer).
+	// 1. Exchange banners (camouflage layer). A single bufio.Reader is shared with
+	// the secure handshake so any bytes read past the banner are not lost.
+	br := bufio.NewReader(conn)
 	if _, err := conn.Write([]byte(GetDynamicSSHBanner())); err != nil {
 		return nil, fmt.Errorf("failed to write client banner: %w", err)
 	}
-	if _, err := readBanner(conn); err != nil {
+	if _, err := readBannerBuffered(br); err != nil {
 		return nil, fmt.Errorf("failed to read server banner: %w", err)
 	}
 
-	// 2. Upgrade to the authenticated, encrypted transport.
-	sc, err := securestream.ClientHandshake(conn, token)
+	// 2. Upgrade to the authenticated, encrypted transport (reads via br).
+	sc, err := securestream.ClientHandshake(conn, br, token)
 	if err != nil {
 		return nil, fmt.Errorf("secure handshake failed: %w", err)
 	}
@@ -174,13 +190,16 @@ func PerformServerHandshake(conn net.Conn, expectedToken string, filter *secures
 		serverBanner = GetDynamicSSHBanner()
 	}
 
+	// Record everything read from the client (for decoy replay on failure), and
+	// read through a single bufio.Reader shared with the secure handshake.
 	rec := &RecorderConn{Conn: conn, recording: true}
+	br := bufio.NewReader(rec)
 
 	// 1. Send our banner, then read + validate the client banner.
 	if _, err := conn.Write([]byte(serverBanner)); err != nil {
 		return nil, buildReplayConn(conn, rec), fmt.Errorf("failed to write server banner: %w", err)
 	}
-	clientBanner, err := readBanner(rec)
+	clientBanner, err := readBannerBuffered(br)
 	if err != nil {
 		return nil, buildReplayConn(conn, rec), fmt.Errorf("failed to read client banner: %w", err)
 	}
@@ -188,9 +207,9 @@ func PerformServerHandshake(conn net.Conn, expectedToken string, filter *secures
 		return nil, buildReplayConn(conn, rec), errors.New("invalid protocol banner signature")
 	}
 
-	// 2. Authenticate over the encrypted transport. A wrong PSK (or a probe that
-	// is not speaking our protocol) fails the AEAD tag -> route to decoy.
-	sc, err := securestream.ServerHandshake(rec, expectedToken, filter)
+	// 2. Authenticate over the encrypted transport (writes to conn, reads via br).
+	// A wrong PSK (or a probe not speaking our protocol) fails the AEAD tag -> decoy.
+	sc, err := securestream.ServerHandshake(conn, br, expectedToken, filter)
 	if err != nil {
 		return nil, buildReplayConn(conn, rec), err
 	}

--- a/internal/mimic/ssh_test.go
+++ b/internal/mimic/ssh_test.go
@@ -1,6 +1,8 @@
 package mimic
 
 import (
+	"bytes"
+	"crypto/rand"
 	"io"
 	"net"
 	"strings"
@@ -9,6 +11,71 @@ import (
 
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/securestream"
 )
+
+// TestHandshakeLargeTransferTCP drives several MB through the full mimic + bufio +
+// securestream path, echoed back, to prove the shared bufio.Reader never loses or
+// corrupts data — including AEAD frames larger than the bufio buffer.
+func TestHandshakeLargeTransferTCP(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	const token = "large-transfer-secret"
+	payload := make([]byte, 3*1024*1024+777)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	srvErr := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			srvErr <- err
+			return
+		}
+		sc, _, err := PerformServerHandshake(conn, token, securestream.NewReplayFilter(0), "")
+		if err != nil {
+			srvErr <- err
+			return
+		}
+		got := make([]byte, len(payload))
+		if _, err := io.ReadFull(sc, got); err != nil {
+			srvErr <- err
+			return
+		}
+		if !bytes.Equal(got, payload) {
+			srvErr <- io.ErrUnexpectedEOF // signal mismatch
+			return
+		}
+		_, err = sc.Write(got) // echo
+		srvErr <- err
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	sc, err := PerformClientHandshake(conn, token)
+	if err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+	go func() { _, _ = io.Copy(sc, bytes.NewReader(payload)) }()
+
+	echo := make([]byte, len(payload))
+	if _, err := io.ReadFull(sc, echo); err != nil {
+		t.Fatalf("client read echo: %v", err)
+	}
+	if !bytes.Equal(echo, payload) {
+		t.Fatal("echoed payload mismatch")
+	}
+	if err := <-srvErr; err != nil {
+		t.Fatalf("server side: %v", err)
+	}
+}
 
 // TestHandshakeRoundTripTCP verifies banner exchange + AEAD upgrade + data flow
 // over a real TCP connection when both sides share the token.
@@ -175,7 +242,7 @@ func TestServerPresentsMirroredBanner(t *testing.T) {
 	}
 	defer conn.Close()
 
-	got, err := readBanner(conn)
+	got, err := readBannerConn(conn)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -2,7 +2,7 @@ package pool
 
 import (
 	"errors"
-	"log"
+	"log/slog"
 	"math/rand"
 	"net"
 	"sync"
@@ -199,7 +199,7 @@ func (np *NodePool) evaluateHealthAndScale() {
 	// 1. Analyze all sessions
 	for _, s := range np.sessions {
 		if s.IsClosed() {
-			log.Printf("[Pool-%s] Purged dead/frozen physical connection.\n", np.Alias)
+			slog.Info("purged dead physical connection", "node", np.Alias)
 			continue
 		}
 
@@ -225,13 +225,13 @@ func (np *NodePool) evaluateHealthAndScale() {
 			if activeCount > np.minConnections && mbps < 1 && s.IdleTime() > dynamicIdleLimit {
 				s.SetDraining() // Shift to Draining (Wait for logical streams to drop to zero)
 				activeCount--
-				log.Printf("[Pool-%s] Scaled DOWN: Connection moved to Draining state (Idle/Low load).\n", np.Alias)
+				slog.Info("scaled down: connection draining (idle/low load)", "node", np.Alias)
 			}
 		} else if s.IsDraining() {
 			// Deep cleanup: Only close a draining session when ALL its streams have naturally finished
 			if s.ActiveStreams() == 0 {
 				s.Close()
-				log.Printf("[Pool-%s] Draining complete. Empty connection closed safely.\n", np.Alias)
+				slog.Info("draining complete: connection closed", "node", np.Alias)
 				continue // Remove from memory
 			}
 		}
@@ -271,7 +271,7 @@ func (np *NodePool) executeScaleUp() {
 	for _, s := range np.sessions {
 		if s.IsDraining() {
 			s.Revive()
-			log.Printf("[Pool-%s] Scaled UP (Revive): Resurrected a draining connection back to Active.\n", np.Alias)
+			slog.Info("scaled up: revived draining connection", "node", np.Alias)
 			np.mu.Unlock()
 			return
 		}
@@ -284,7 +284,7 @@ func (np *NodePool) executeScaleUp() {
 	if totalConns < np.maxConnections {
 		np.replenishPool(1)
 	} else {
-		log.Printf("[Pool-%s] Warning: Max physical limits reached (%d). Cannot scale further.\n", np.Alias, np.maxConnections)
+		slog.Warn("max physical connections reached", "node", np.Alias, "max", np.maxConnections)
 	}
 }
 
@@ -301,13 +301,13 @@ func (np *NodePool) replenishPool(needed int) {
 			np.mu.Lock()
 			if len(np.sessions) < np.maxConnections {
 				np.sessions = append(np.sessions, wrappedSession)
-				log.Printf("[Pool-%s] Scaled UP (Dial): +1 connection established. Total Pipes: %d/%d\n", np.Alias, len(np.sessions), np.maxConnections)
+				slog.Info("scaled up: dialed new connection", "node", np.Alias, "total", len(np.sessions), "max", np.maxConnections)
 			} else {
 				wrappedSession.Close()
 			}
 			np.mu.Unlock()
 		} else {
-			log.Printf("[Pool-%s] Failed to dial new connection: %v\n", np.Alias, err)
+			slog.Warn("failed to dial new connection", "node", np.Alias, "err", err)
 		}
 	}
 }

--- a/internal/securestream/securestream.go
+++ b/internal/securestream/securestream.go
@@ -63,6 +63,11 @@ var (
 type SecureConn struct {
 	net.Conn
 
+	// reader is the source for all decrypted reads. It is a bufio.Reader shared
+	// with the banner exchange so any bytes buffered past the banner (salt/first
+	// frame) are not lost. Writes still go to the embedded net.Conn.
+	reader io.Reader
+
 	readMu   sync.Mutex
 	rAEAD    cipher.AEAD
 	rNonce   [nonceSize]byte
@@ -94,8 +99,9 @@ func incrementNonce(n *[nonceSize]byte) {
 
 // ClientHandshake performs the client side of the upgrade over an already
 // banner-exchanged connection: it sends its salt + an authentication frame,
-// then reads the server's salt. token is the pre-shared secret (never sent).
-func ClientHandshake(conn net.Conn, token string) (*SecureConn, error) {
+// then reads the server's salt. Reads come from r (the buffered reader shared
+// with the banner exchange); writes go to conn. token is the pre-shared secret.
+func ClientHandshake(conn net.Conn, r io.Reader, token string) (*SecureConn, error) {
 	_ = conn.SetDeadline(time.Now().Add(hsDeadline))
 	defer conn.SetDeadline(time.Time{})
 
@@ -118,7 +124,7 @@ func ClientHandshake(conn net.Conn, token string) (*SecureConn, error) {
 		return nil, err
 	}
 
-	sc := newSecureConn(conn)
+	sc := newSecureConn(conn, r)
 	sc.wAEAD = wAEAD
 
 	// 2. Send the authentication frame: the magic marker, proven authentic by its
@@ -130,7 +136,7 @@ func ClientHandshake(conn net.Conn, token string) (*SecureConn, error) {
 
 	// 3. Read the server salt and derive the read key.
 	saltS := make([]byte, saltSize)
-	if _, err := io.ReadFull(conn, saltS); err != nil {
+	if _, err := io.ReadFull(r, saltS); err != nil {
 		return nil, fmt.Errorf("read server salt: %w", err)
 	}
 	rKey, err := deriveKey(psk, saltS)
@@ -149,7 +155,7 @@ func ClientHandshake(conn net.Conn, token string) (*SecureConn, error) {
 // ServerHandshake performs the server side of the upgrade. It reads the client
 // salt + auth frame; on any authentication failure it returns ErrAuth so the
 // caller can divert to the decoy. filter may be nil to skip replay protection.
-func ServerHandshake(conn net.Conn, token string, filter *ReplayFilter) (*SecureConn, error) {
+func ServerHandshake(conn net.Conn, r io.Reader, token string, filter *ReplayFilter) (*SecureConn, error) {
 	_ = conn.SetDeadline(time.Now().Add(hsDeadline))
 	defer conn.SetDeadline(time.Time{})
 
@@ -157,7 +163,7 @@ func ServerHandshake(conn net.Conn, token string, filter *ReplayFilter) (*Secure
 
 	// 1. Read the client salt and derive the read key.
 	saltC := make([]byte, saltSize)
-	if _, err := io.ReadFull(conn, saltC); err != nil {
+	if _, err := io.ReadFull(r, saltC); err != nil {
 		return nil, fmt.Errorf("read client salt: %w", err)
 	}
 	rKey, err := deriveKey(psk, saltC)
@@ -169,7 +175,7 @@ func ServerHandshake(conn net.Conn, token string, filter *ReplayFilter) (*Secure
 		return nil, err
 	}
 
-	sc := newSecureConn(conn)
+	sc := newSecureConn(conn, r)
 	sc.rAEAD = rAEAD
 
 	// 2. Read + verify the authentication frame. A wrong PSK yields a wrong key
@@ -209,9 +215,13 @@ func ServerHandshake(conn net.Conn, token string, filter *ReplayFilter) (*Secure
 	return sc, nil
 }
 
-func newSecureConn(conn net.Conn) *SecureConn {
+func newSecureConn(conn net.Conn, r io.Reader) *SecureConn {
+	if r == nil {
+		r = conn
+	}
 	return &SecureConn{
 		Conn:    conn,
+		reader:  r,
 		lenBuf:  make([]byte, lenHdrLen+tagSize),
 		payBuf:  make([]byte, maxChunk+tagSize),
 		padBuf:  make([]byte, maxPad),
@@ -273,7 +283,7 @@ func (c *SecureConn) Write(p []byte) (int, error) {
 // returns the payload as a slice into c.payBuf.
 func (c *SecureConn) readChunk() ([]byte, error) {
 	// Length header.
-	if _, err := io.ReadFull(c.Conn, c.lenBuf); err != nil {
+	if _, err := io.ReadFull(c.reader, c.lenBuf); err != nil {
 		return nil, err
 	}
 	hdr, err := c.rAEAD.Open(c.lenBuf[:0], c.rNonce[:], c.lenBuf, nil)
@@ -289,7 +299,7 @@ func (c *SecureConn) readChunk() ([]byte, error) {
 
 	// Payload block.
 	enc := c.payBuf[:payloadLen+tagSize]
-	if _, err := io.ReadFull(c.Conn, enc); err != nil {
+	if _, err := io.ReadFull(c.reader, enc); err != nil {
 		return nil, err
 	}
 	plain, err := c.rAEAD.Open(enc[:0], c.rNonce[:], enc, nil)
@@ -300,7 +310,7 @@ func (c *SecureConn) readChunk() ([]byte, error) {
 
 	// Discard the trailing random padding.
 	if padLen > 0 {
-		if _, err := io.ReadFull(c.Conn, c.padBuf[:padLen]); err != nil {
+		if _, err := io.ReadFull(c.reader, c.padBuf[:padLen]); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/securestream/securestream_test.go
+++ b/internal/securestream/securestream_test.go
@@ -22,11 +22,11 @@ func handshakePair(t *testing.T, clientTok, serverTok string, filter *ReplayFilt
 	}
 	srvCh := make(chan res, 1)
 	go func() {
-		sc, err := ServerHandshake(s, serverTok, filter)
+		sc, err := ServerHandshake(s, s, serverTok, filter)
 		srvCh <- res{sc, err}
 	}()
 
-	cli, cerr := ClientHandshake(c, clientTok)
+	cli, cerr := ClientHandshake(c, c, clientTok)
 	sr := <-srvCh
 
 	if cerr != nil {
@@ -92,12 +92,12 @@ func TestWrongTokenFailsAuth(t *testing.T) {
 	c, s := net.Pipe()
 	srvErr := make(chan error, 1)
 	go func() {
-		_, err := ServerHandshake(s, "server-token", nil)
+		_, err := ServerHandshake(s, s, "server-token", nil)
 		s.Close()
 		srvErr <- err
 	}()
 	go func() {
-		if cli, err := ClientHandshake(c, "client-token"); err == nil {
+		if cli, err := ClientHandshake(c, c, "client-token"); err == nil {
 			cli.Close()
 		}
 		c.Close()
@@ -163,7 +163,7 @@ func (s *sizeRecorder) Write(p []byte) (int, error) {
 // fingerprinted by size.
 func TestPaddingVariesFrameSize(t *testing.T) {
 	rec := &sizeRecorder{}
-	sc := newSecureConn(rec)
+	sc := newSecureConn(rec, nil)
 	aead, err := chacha20poly1305.New(make([]byte, keySize))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sysutil/ops.go
+++ b/internal/sysutil/ops.go
@@ -2,6 +2,8 @@ package sysutil
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -14,9 +16,13 @@ import (
 const (
 	binaryPath = "/usr/local/bin/hedioum-tunnel"
 	backupPath = "/usr/local/bin/hedioum-tunnel.bak"
-	tmpPath    = "/tmp/hedioum-tunnel-new"
-	repoAPI    = "https://api.github.com/repos/hedioum/Hedioum-Pool-Tunnel/releases/latest"
-	proxyURL   = "https://ghp.ci/"
+	// stagePath is deliberately in the SAME directory as binaryPath so the final
+	// swap is an atomic same-filesystem rename (a /tmp staging area risks EXDEV).
+	stagePath = "/usr/local/bin/hedioum-tunnel.new"
+	repoAPI   = "https://api.github.com/repos/hedioum/Hedioum-Pool-Tunnel/releases/latest"
+
+	minBinarySize    = 1024 * 1024 // sanity floor for a real binary
+	downloadAttempts = 3
 )
 
 // GitHubRelease represents the structure of the GitHub API response
@@ -28,122 +34,163 @@ type GitHubRelease struct {
 	} `json:"assets"`
 }
 
-// SelfUpdate orchestrates a safe zero-downtime update with an automatic rollback mechanism.
+// SelfUpdate downloads and installs a newer release from GitHub, with retries,
+// a semver "is-newer" check, and automatic rollback. When GitHub is unreachable
+// (e.g. filtered) it prints the manual path: download the binary and run
+// `hedioum-tunnel update --file /path`.
 func SelfUpdate(currentVersion string) {
-	color.Cyan("[*] Checking for updates (Timeout: 5s)...")
+	color.Cyan("[*] Checking for updates...")
 
-	// 1. Fetch latest release info
-	client := http.Client{
-		Timeout: 5 * time.Second,
-	}
-	resp, err := client.Get(repoAPI)
+	release, err := fetchLatestRelease()
 	if err != nil {
-		color.Red("[x] Failed to contact GitHub API: %v", err)
-		color.Yellow("    (This is common on restricted networks. Ensure your server can reach GitHub).")
+		color.Red("[x] Failed to query GitHub: %v", err)
+		manualHint()
 		return
 	}
-	defer resp.Body.Close()
-
-	// CRITICAL FIX: Ensure the API returned a 200 OK status before parsing
-	if resp.StatusCode != http.StatusOK {
-		color.Red("[x] GitHub API returned an error: HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
-		if resp.StatusCode == http.StatusForbidden {
-			color.Yellow("    [-] You have likely hit the GitHub API rate limit. Please try again later.")
-		}
-		return
-	}
-
-	var release GitHubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		color.Red("[x] Failed to parse GitHub API response: %v", err)
-		return
-	}
-
-	if release.TagName == "" || release.TagName == currentVersion {
+	if release.TagName == "" || !IsNewer(release.TagName, currentVersion) {
 		color.Green("[✓] You are already running the latest version (%s).", currentVersion)
 		return
 	}
 
-	// 2. Detect OS Architecture to select the correct binary
-	targetAsset := "hedioum-tunnel"
-	if runtime.GOARCH == "arm64" {
-		targetAsset = "hedioum-tunnel-arm64"
+	asset := targetAsset()
+	url := assetURL(release, asset)
+	if url == "" {
+		color.Red("[x] Release %s has no '%s' binary.", release.TagName, asset)
+		return
 	}
 
-	var downloadURL string
-	for _, asset := range release.Assets {
-		if asset.Name == targetAsset {
-			downloadURL = asset.BrowserDownloadURL
-			break
+	color.Yellow("[*] New version %s found. Downloading (%d attempts)...", release.TagName, downloadAttempts)
+	defer os.Remove(stagePath)
+	if err := downloadWithRetry(url, stagePath, downloadAttempts); err != nil {
+		color.Red("[x] Download failed: %v", err)
+		manualHint()
+		return
+	}
+	installStaged(release.TagName)
+}
+
+// UpdateFromFile installs a locally-provided binary (the manual fallback when
+// GitHub is blocked), using the same backup/rollback flow.
+func UpdateFromFile(path string) {
+	color.Cyan("[*] Installing from %s ...", path)
+	if err := copyFile(path, stagePath); err != nil {
+		color.Red("[x] Could not read %s: %v", path, err)
+		return
+	}
+	defer os.Remove(stagePath)
+	installStaged("manual:" + path)
+}
+
+// fetchLatestRelease queries the GitHub releases API.
+func fetchLatestRelease() (*GitHubRelease, error) {
+	client := http.Client{Timeout: 8 * time.Second}
+	resp, err := client.Get(repoAPI)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("HTTP 403 (likely API rate limit); try later")
+		}
+		return nil, fmt.Errorf("HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+	var release GitHubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+	return &release, nil
+}
+
+func targetAsset() string {
+	if runtime.GOARCH == "arm64" {
+		return "hedioum-tunnel-arm64"
+	}
+	return "hedioum-tunnel"
+}
+
+func assetURL(release *GitHubRelease, name string) string {
+	for _, a := range release.Assets {
+		if a.Name == name {
+			return a.BrowserDownloadURL
 		}
 	}
+	return ""
+}
 
-	if downloadURL == "" {
-		color.Red("[x] Could not find '%s' binary in the latest release.", targetAsset)
+// downloadWithRetry downloads url to dst directly from GitHub, retrying transient
+// failures. No third-party proxy is used.
+func downloadWithRetry(url, dst string, attempts int) error {
+	var err error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			color.Yellow("[-] Attempt %d failed; retrying...", i)
+			time.Sleep(2 * time.Second)
+		}
+		if err = exec.Command("curl", "-f", "-L", "-s", "-o", dst, url).Run(); err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
+func manualHint() {
+	color.Yellow("    GitHub may be blocked. Download '%s' manually and run:", targetAsset())
+	color.HiWhite("      hedioum-tunnel update --file /path/to/%s", targetAsset())
+}
+
+// installStaged swaps stagePath into place with backup + restart + health-check +
+// rollback. stagePath and binaryPath share a directory, so the swap is atomic.
+func installStaged(label string) {
+	if st, err := os.Stat(stagePath); err != nil || st.Size() < minBinarySize {
+		color.Red("[x] Staged binary missing or too small; aborting update.")
 		return
 	}
+	os.Chmod(stagePath, 0755)
 
-	color.Yellow("[*] New version found: %s. Starting safe update...", release.TagName)
-
-	// CRITICAL FIX: Ensure the temporary file is always cleaned up if the function returns early
-	defer os.Remove(tmpPath)
-
-	// 3. Download the new binary safely to /tmp
-	if err := downloadFile(tmpPath, downloadURL); err != nil {
-		color.Red("[x] Download failed: %v", err)
-		return
-	}
-
-	// Integrity check
-	stat, err := os.Stat(tmpPath)
-	if err != nil || stat.Size() < 1024*1024 {
-		color.Red("[x] Downloaded file appears corrupted or too small. Aborting update.")
-		return
-	}
-
-	// 4. Backup current working binary
-	color.Cyan("[*] Creating backup of current version...")
+	color.Cyan("[*] Backing up the current binary...")
 	if err := os.Rename(binaryPath, backupPath); err != nil {
 		color.Red("[x] Failed to create backup: %v", err)
 		return
 	}
-
-	// 5. Install new binary
-	if err := os.Rename(tmpPath, binaryPath); err != nil {
-		color.Red("[x] Failed to deploy new binary. Rolling back...")
+	if err := os.Rename(stagePath, binaryPath); err != nil {
+		color.Red("[x] Failed to deploy new binary; rolling back...")
 		rollback()
 		return
 	}
 	os.Chmod(binaryPath, 0755)
 
-	// 6. Restart service and Verify
-	color.Cyan("[*] Restarting daemon to apply version %s...", release.TagName)
+	color.Cyan("[*] Restarting daemon...")
 	exec.Command("systemctl", "restart", "hedioum.service").Run()
 	time.Sleep(2 * time.Second)
-
-	// 7. Health Check & Rollback
 	if err := exec.Command("systemctl", "is-active", "--quiet", "hedioum.service").Run(); err != nil {
-		color.HiRed("[!] CRITICAL: New version crashed upon startup. Initiating auto-rollback!")
+		color.HiRed("[!] New version failed to start; rolling back!")
 		rollback()
 		return
 	}
 
-	// Cleanup backup on success
 	os.Remove(backupPath)
-	color.Green("\n[✓] Update successful! Hedioum Daemon is now running %s.", release.TagName)
+	color.Green("\n[✓] Update successful (%s).", label)
 }
 
-// downloadFile tries the direct link, and falls back to a proxy if blocked
-func downloadFile(filepath string, url string) error {
-	cmd := exec.Command("curl", "-f", "-L", "-s", "-o", filepath, url)
-	if err := cmd.Run(); err == nil {
-		return nil
+// copyFile copies src to dst (used for the manual --file path; handles src on a
+// different filesystem than dst).
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
 	}
-
-	color.Yellow("[-] Direct download failed. Attempting via proxy fallback...")
-	proxyLink := proxyURL + url
-	cmdProxy := exec.Command("curl", "-f", "-L", "-s", "-o", filepath, proxyLink)
-	return cmdProxy.Run()
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(dst)
+		return err
+	}
+	return out.Close()
 }
 
 // rollback restores the previous binary and restarts the service

--- a/internal/sysutil/semver.go
+++ b/internal/sysutil/semver.go
@@ -1,0 +1,50 @@
+package sysutil
+
+import (
+	"strconv"
+	"strings"
+)
+
+// IsNewer reports whether candidate is a strictly newer semantic version than
+// current. Both may carry a leading 'v' and an optional pre-release/build suffix
+// (which is ignored). If either cannot be parsed, it falls back to inequality
+// (update when the tags simply differ) so an odd/dev current version still
+// updates to a real release.
+func IsNewer(candidate, current string) bool {
+	cp, ok1 := parseSemver(candidate)
+	cc, ok2 := parseSemver(current)
+	if !ok1 || !ok2 {
+		return candidate != "" && candidate != current
+	}
+	for i := 0; i < 3; i++ {
+		if cp[i] != cc[i] {
+			return cp[i] > cc[i]
+		}
+	}
+	return false
+}
+
+// parseSemver parses "vMAJOR[.MINOR[.PATCH]]" (missing parts = 0), ignoring any
+// -prerelease or +build suffix.
+func parseSemver(s string) ([3]int, bool) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "v")
+	if i := strings.IndexAny(s, "-+"); i >= 0 {
+		s = s[:i]
+	}
+	if s == "" {
+		return [3]int{}, false
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) > 3 {
+		return [3]int{}, false
+	}
+	var out [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return [3]int{}, false
+		}
+		out[i] = n
+	}
+	return out, true
+}

--- a/internal/sysutil/semver_test.go
+++ b/internal/sysutil/semver_test.go
@@ -1,0 +1,26 @@
+package sysutil
+
+import "testing"
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		cand, cur string
+		want      bool
+	}{
+		{"v0.6.0", "v0.3.2", true},      // the real upgrade path
+		{"v0.6.0", "v0.6.0", false},     // equal
+		{"v0.6.1", "v0.6.0", true},      // patch bump
+		{"v0.5.0", "v0.6.0", false},     // older release than current
+		{"v1.0.0", "v0.9.9", true},      // major bump
+		{"0.6.0", "v0.6.0", false},      // missing 'v' still equal
+		{"v0.6", "v0.6.0", false},       // v0.6 == v0.6.0
+		{"v0.6.0-rc1", "v0.6.0", false}, // prerelease suffix ignored -> equal
+		{"v0.6.0", "dev", true},         // unparseable current -> update to a real release
+		{"", "v0.6.0", false},           // empty candidate never newer
+	}
+	for _, c := range cases {
+		if got := IsNewer(c.cand, c.cur); got != c.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v", c.cand, c.cur, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
# Milestone 3 — DevSecOps & Observability (v0.6.0)

> **Non-breaking feature release.** The wire protocol is unchanged from v0.5.0, so v0.5 and v0.6 nodes interoperate — no forced simultaneous update.

## Why
Make the tunnel operable and automatable: structured logs you can actually debug, install/configure with zero interactivity, deploy when GitHub is filtered, and update safely.

## What changed

### Structured logging (`log/slog`)
The daemon mixed `log.Printf` + `color.*`, so journald got ANSI junk. New `internal/logging` handler writes color-free lines with an sd-daemon syslog priority (`<6>`..`<3>`) so `journalctl -p` works; level via `HEDIOUM_LOG_LEVEL`. All daemon logging (pool/egress/ingress) moved to slog; the interactive TUI keeps color. Added **Debug** logs at the previously-silent drop points (SOCKS handshake failure, pool exhausted, unsupported command).

### Non-interactive CLI + self-install
A dependency-free subcommand router (no-arg = dashboard/daemon, unchanged):
```
version · install · uninstall [--yes] · update [--file PATH]
setup-foreign · setup-iran · add-node · remove-node
```
- Strict shared validators (port 1..65535, IP, HOST:PORT, hex token) — replaces the loose `safeAtoi` that accepted >65535.
- `install` self-copies the running binary (temp+rename) and installs the systemd unit from an **embedded template** (single source of truth: M1/M2 hardening + `ExecStartPre=+ --open-firewall` + `After=ssh`). No download → works when GitHub is filtered (GitHub #1).

### Configurable decoy/listen ports
`config.DecoyPort` (default 2022); the hardcoded `decoySSHPrt` is gone (threaded from config into the banner mirror + decoy proxy). The wizard/CLI ask both ports (default 22/2022) with a warning that a non-22 listen weakens the SSH mimic. Fixes the "outbound :22 blocked in some Iran DCs" deploy blocker.

### Buffered banner reads
The mimic handshake now shares **one `bufio.Reader`** with the secure handshake, removing the byte-by-byte banner loop; bytes read past the banner (salt/first frame) are no longer at risk. `securestream` reads via an injected `io.Reader` (writes stay on the raw conn). The decoy path keeps the byte-by-byte reader (its trailing bytes are piped raw and must not be buffered).

### Robust, ghp.ci-free self-update
Dropped the third-party `ghp.ci` proxy (MITM surface). Direct GitHub download with **retries**; a **semver "is-newer"** check (so v0.3.2 → v0.6.0 upgrades cleanly); staged in the target dir for an **atomic same-fs swap**; backup + restart + health-check + **rollback**. GitHub blocked? It prints the manual path: `hedioum-tunnel update --file /path/to/binary`. (Cryptographic release signing intentionally deferred.)

### Minimal bootstrap + version info
`install.sh` slimmed to: detect arch → download → run the binary (the binary does the rest). `hedioum-tunnel version` prints version/commit/date (`-ldflags -X`). New `docs/DEPLOY.md` covers interactive, manual, and Ansible-style installs.

## Tests (all green with `-race`, amd64+arm64 built)
- `logging`: format/priority/level-filtering/attrs.
- `cli`: validator table (port/IP/target/token).
- `sysutil`: `IsNewer` semver table (upgrade/equal/older/prerelease/dev).
- `mimic`/`securestream`: handshake + round-trip + partial-read re-run under the new bufio path, plus a **3 MB echo transfer** through the full mimic+bufio+securestream stack (frames larger than the bufio buffer).
- Regression: full suite green.