### PR TITLE
v0.7.2 — wizard mimic selection (fix UI installs getting SSH-only) + tcp/udp pool logging

### DIFF
--- a/cmd/hedioum/main.go
+++ b/cmd/hedioum/main.go
@@ -23,7 +23,7 @@ import (
 // so v0.5 and v0.6 nodes interoperate): structured slog logging, non-interactive
 // CLI + self-install, configurable decoy/listen ports, buffered banner reads, and
 // a ghp.ci-free, signature-free-but-robust self-update.
-const AppVersion = "v0.7.1"
+const AppVersion = "v0.7.2"
 
 func main() {
 	// Management subcommands (a non-flag first argument): install, setup-*, etc.

--- a/cmd/hedioum/wizard.go
+++ b/cmd/hedioum/wizard.go
@@ -58,36 +58,51 @@ func setupForeignNode(cfg *config.AppConfig) {
 		Default: detectedIP,
 	}, &ip, survey.WithValidator(survey.Required))
 
-	// Public listen port (default 22). A non-22 port helps when outbound :22 is
-	// blocked, but weakens the SSH mimic.
-	var listenPortStr string
-	survey.AskOne(&survey.Input{Message: "Public listen port:", Default: "22"}, &listenPortStr)
-	listenPort := clampPort(listenPortStr, 22)
-	if listenPort != 22 {
-		color.Yellow("[!] Listen port %d: the SSH mimic is most convincing on 22; a non-22 port may be easier to fingerprint.", listenPort)
+	// Which camouflages this node listens behind (checkbox; "all" = whole arsenal).
+	mimics := promptMimics()
+
+	// SSH-specific prompts only matter when the SSH mimic is enabled.
+	listenPort := 22
+	decoyPort := 2022
+	if containsStr(mimics, "ssh") {
+		var listenPortStr string
+		survey.AskOne(&survey.Input{Message: "SSH mimic public port:", Default: "22"}, &listenPortStr)
+		listenPort = clampPort(listenPortStr, 22)
+		if listenPort != 22 {
+			color.Yellow("[!] SSH mimic on port %d: it is most convincing on 22.", listenPort)
+		}
+
+		var decoyPortStr string
+		survey.AskOne(&survey.Input{Message: "Decoy sshd port (OpenSSH is moved here):", Default: "2022"}, &decoyPortStr)
+		decoyPort = clampPort(decoyPortStr, 2022)
+
+		changeSSH := false
+		survey.AskOne(&survey.Confirm{
+			Message: fmt.Sprintf("Move OpenSSH to port %d to free port %d for the SSH mimic?", decoyPort, listenPort),
+			Default: true,
+		}, &changeSSH)
+		if changeSSH {
+			if err := sysutil.ChangeSSHPort(strconv.Itoa(decoyPort)); err != nil {
+				color.Red("[x] OpenSSH port relocation failed: %v", err)
+			} else {
+				color.Green("[✓] OpenSSH shifted to %d. Decoy port available.", decoyPort)
+			}
+		}
 	}
 
-	// Decoy sshd port (OpenSSH is relocated here).
-	var decoyPortStr string
-	survey.AskOne(&survey.Input{Message: "Decoy sshd port (OpenSSH is moved here):", Default: "2022"}, &decoyPortStr)
-	decoyPort := clampPort(decoyPortStr, 2022)
-
-	changeSSH := false
-	survey.AskOne(&survey.Confirm{
-		Message: fmt.Sprintf("Move OpenSSH to port %d to free port %d for the tunnel/decoy?", decoyPort, listenPort),
-		Default: true,
-	}, &changeSSH)
-
-	if changeSSH {
-		if err := sysutil.ChangeSSHPort(strconv.Itoa(decoyPort)); err != nil {
-			color.Red("[x] OpenSSH port relocation failed: %v", err)
-		} else {
-			color.Green("[✓] OpenSSH shifted to %d. Decoy port available.", decoyPort)
+	// Build one listener per selected mimic on its conventional port.
+	var mimicList []config.MimicListener
+	for _, ty := range mimics {
+		ml := config.MimicListener{Type: ty, Port: mimicPort(ty, listenPort)}
+		if ty == "ssh" {
+			ml.Decoy = fmt.Sprintf("127.0.0.1:%d", decoyPort)
 		}
+		mimicList = append(mimicList, ml)
 	}
 
 	cfg.ForeignListenPort = listenPort
 	cfg.DecoyPort = decoyPort
+	cfg.Mimics = mimicList
 	cfg.AuthToken = sysutil.GenerateSecureToken()
 
 	// IPv6 egress is opt-in (default IPv4-only to avoid leaking the v6 identity).
@@ -113,8 +128,12 @@ func setupForeignNode(cfg *config.AppConfig) {
 	}
 
 	color.HiWhite("\n[INFO] Provisioning Summary:")
-	fmt.Printf(" - Listen Port: %d\n", cfg.ForeignListenPort)
-	fmt.Printf(" - Auth Token:  %s\n", color.HiYellowString(cfg.AuthToken))
+	labels := make([]string, len(mimicList))
+	for i, m := range mimicList {
+		labels[i] = fmt.Sprintf("%s:%d", m.Type, m.Port)
+	}
+	fmt.Printf(" - Mimics:     %s\n", strings.Join(labels, ", "))
+	fmt.Printf(" - Auth Token: %s\n", color.HiYellowString(cfg.AuthToken))
 	color.HiRed("   (CRITICAL: Retain this token for Iran Hub configuration)\n")
 }
 
@@ -137,7 +156,7 @@ func setupIranNode(cfg *config.AppConfig, isFirstTime bool) {
 		},
 		{
 			Name:   "targetport",
-			Prompt: &survey.Input{Message: "Foreign Egress Port:", Default: "22"},
+			Prompt: &survey.Input{Message: "Foreign SSH mimic port (other mimics use standard ports):", Default: "22"},
 		},
 		{
 			Name:   "localsocksport",
@@ -193,6 +212,17 @@ func setupIranNode(cfg *config.AppConfig, isFirstTime bool) {
 	node.MaxConnections = safeAtoi(answers.MaxConnections, 20)
 	node.BandwidthLimitMbps = safeAtoi(answers.BandwidthLimit, 8)
 	node.BandwidthJitterMbps = safeAtoi(answers.BandwidthJitter, 2)
+
+	// Which mimics to reach this node over (checkbox; must match what the foreign
+	// node runs). Populating Endpoints is what enables the multi-mimic arsenal —
+	// without it the node falls back to a single synthesized SSH endpoint.
+	for _, ty := range promptMimics() {
+		node.Endpoints = append(node.Endpoints, config.Endpoint{
+			Target: net.JoinHostPort(node.TargetIP, strconv.Itoa(mimicPort(ty, node.TargetPort))),
+			Mimic:  ty,
+		})
+	}
+	color.Green("[✓] Endpoints: %d mimic(s) toward %s", len(node.Endpoints), node.TargetIP)
 
 	cfg.UpdateForeignNode(node)
 }
@@ -258,4 +288,69 @@ func safeAtoi(s string, defaultVal int) int {
 		return defaultVal
 	}
 	return val
+}
+
+// allMimics is the full camouflage arsenal, in the order the wizard offers it.
+var allMimics = []string{"ssh", "tls", "smtp", "imap", "smtps", "imaps"}
+
+// promptMimics shows a checkbox selection of camouflage protocols and returns the
+// chosen types. The first option ("all") selects the whole arsenal. Never returns
+// empty (falls back to ssh+tls), so a config always has at least one listener.
+func promptMimics() []string {
+	const allOpt = "all (enable every mimic)"
+	var sel []string
+	survey.AskOne(&survey.MultiSelect{
+		Message: "Select camouflage protocols (Space toggles, Enter confirms):",
+		Options: append([]string{allOpt}, allMimics...),
+		Default: []string{"ssh", "tls"},
+		Help:    "tls=HTTPS:443, ssh=22, smtp=587, imap=143, smtps=465, imaps=993. Run several for a stronger, shifting signature.",
+	}, &sel)
+
+	chosen := map[string]bool{}
+	for _, s := range sel {
+		if s == allOpt {
+			return append([]string{}, allMimics...)
+		}
+		chosen[s] = true
+	}
+	var out []string
+	for _, t := range allMimics {
+		if chosen[t] {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		out = []string{"ssh", "tls"} // never leave a node with no camouflage
+	}
+	return out
+}
+
+// mimicPort maps a mimic type to its conventional port; the SSH port is caller-set
+// so the operator can relocate it when outbound :22 is blocked.
+func mimicPort(ty string, sshPort int) int {
+	switch ty {
+	case "ssh":
+		return sshPort
+	case "tls":
+		return 443
+	case "smtp":
+		return 587
+	case "imap":
+		return 143
+	case "smtps":
+		return 465
+	case "imaps":
+		return 993
+	}
+	return 0
+}
+
+// containsStr reports whether s is in list.
+func containsStr(list []string, s string) bool {
+	for _, x := range list {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/hedioum/wizard_test.go
+++ b/cmd/hedioum/wizard_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+func TestMimicPort(t *testing.T) {
+	// SSH port is caller-configurable; the rest are conventional.
+	if got := mimicPort("ssh", 2200); got != 2200 {
+		t.Errorf("ssh port = %d, want 2200 (caller-set)", got)
+	}
+	want := map[string]int{"tls": 443, "smtp": 587, "imap": 143, "smtps": 465, "imaps": 993}
+	for ty, p := range want {
+		if got := mimicPort(ty, 22); got != p {
+			t.Errorf("mimicPort(%q) = %d, want %d", ty, got, p)
+		}
+	}
+	if got := mimicPort("bogus", 22); got != 0 {
+		t.Errorf("unknown mimic should map to 0, got %d", got)
+	}
+}
+
+func TestContainsStr(t *testing.T) {
+	list := []string{"ssh", "tls", "imaps"}
+	if !containsStr(list, "tls") || containsStr(list, "smtp") {
+		t.Fatalf("containsStr wrong: %v", list)
+	}
+	if containsStr(nil, "x") {
+		t.Fatal("containsStr(nil) should be false")
+	}
+}
+
+// TestAllMimicsComplete guards that the wizard's arsenal list stays in sync with
+// the six supported mimic types (so "all" really means all).
+func TestAllMimicsComplete(t *testing.T) {
+	want := map[string]bool{"ssh": true, "tls": true, "smtp": true, "imap": true, "smtps": true, "imaps": true}
+	if len(allMimics) != len(want) {
+		t.Fatalf("allMimics = %v, want %d types", allMimics, len(want))
+	}
+	for _, m := range allMimics {
+		if !want[m] {
+			t.Errorf("unexpected mimic in allMimics: %q", m)
+		}
+		if mimicPort(m, 22) == 0 {
+			t.Errorf("allMimics entry %q has no port mapping", m)
+		}
+	}
+}

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -33,6 +33,7 @@ type PoolStats struct {
 // NodePool manages an auto-scaling pool of Yamux sessions to a single foreign server.
 type NodePool struct {
 	Alias          string
+	label          string // "tcp" or "udp" — which sub-pool, for observability in logs
 	TargetIP       string
 	minConnections int
 	maxConnections int
@@ -75,9 +76,10 @@ func NewHubManager() *HubManager {
 }
 
 // newNodePool builds and starts a monitored connection pool.
-func newNodePool(cfg config.ForeignNode, minConns, maxConns int, dialer DialFunc) *NodePool {
+func newNodePool(cfg config.ForeignNode, label string, minConns, maxConns int, dialer DialFunc) *NodePool {
 	pool := &NodePool{
 		Alias:          cfg.Alias,
+		label:          label,
 		TargetIP:       cfg.TargetIP,
 		minConnections: minConns,
 		maxConnections: maxConns,
@@ -106,8 +108,8 @@ func (hm *HubManager) RegisterNode(cfg config.ForeignNode, dialer DialFunc) {
 	}
 
 	hm.pools[cfg.Alias] = &nodePools{
-		tcp: newNodePool(cfg, minConns, maxConns, dialer),
-		udp: newNodePool(cfg, udpMinConns, udpMaxConns, dialer),
+		tcp: newNodePool(cfg, "tcp", minConns, maxConns, dialer),
+		udp: newNodePool(cfg, "udp", udpMinConns, udpMaxConns, dialer),
 	}
 }
 
@@ -199,7 +201,7 @@ func (np *NodePool) evaluateHealthAndScale() {
 	// 1. Analyze all sessions
 	for _, s := range np.sessions {
 		if s.IsClosed() {
-			slog.Info("purged dead physical connection", "node", np.Alias)
+			slog.Info("purged dead physical connection", "node", np.Alias, "pool", np.label)
 			continue
 		}
 
@@ -225,13 +227,13 @@ func (np *NodePool) evaluateHealthAndScale() {
 			if activeCount > np.minConnections && mbps < 1 && s.IdleTime() > dynamicIdleLimit {
 				s.SetDraining() // Shift to Draining (Wait for logical streams to drop to zero)
 				activeCount--
-				slog.Info("scaled down: connection draining (idle/low load)", "node", np.Alias)
+				slog.Info("scaled down: connection draining (idle/low load)", "node", np.Alias, "pool", np.label)
 			}
 		} else if s.IsDraining() {
 			// Deep cleanup: Only close a draining session when ALL its streams have naturally finished
 			if s.ActiveStreams() == 0 {
 				s.Close()
-				slog.Info("draining complete: connection closed", "node", np.Alias)
+				slog.Info("draining complete: connection closed", "node", np.Alias, "pool", np.label)
 				continue // Remove from memory
 			}
 		}
@@ -271,7 +273,7 @@ func (np *NodePool) executeScaleUp() {
 	for _, s := range np.sessions {
 		if s.IsDraining() {
 			s.Revive()
-			slog.Info("scaled up: revived draining connection", "node", np.Alias)
+			slog.Info("scaled up: revived draining connection", "node", np.Alias, "pool", np.label)
 			np.mu.Unlock()
 			return
 		}
@@ -284,7 +286,7 @@ func (np *NodePool) executeScaleUp() {
 	if totalConns < np.maxConnections {
 		np.replenishPool(1)
 	} else {
-		slog.Warn("max physical connections reached", "node", np.Alias, "max", np.maxConnections)
+		slog.Warn("max physical connections reached", "node", np.Alias, "pool", np.label, "max", np.maxConnections)
 	}
 }
 
@@ -301,13 +303,13 @@ func (np *NodePool) replenishPool(needed int) {
 			np.mu.Lock()
 			if len(np.sessions) < np.maxConnections {
 				np.sessions = append(np.sessions, wrappedSession)
-				slog.Info("scaled up: dialed new connection", "node", np.Alias, "total", len(np.sessions), "max", np.maxConnections)
+				slog.Info("scaled up: dialed new connection", "node", np.Alias, "pool", np.label, "total", len(np.sessions), "max", np.maxConnections)
 			} else {
 				wrappedSession.Close()
 			}
 			np.mu.Unlock()
 		} else {
-			slog.Warn("failed to dial new connection", "node", np.Alias, "err", err)
+			slog.Warn("failed to dial new connection", "node", np.Alias, "pool", np.label, "err", err)
 		}
 	}
 }


### PR DESCRIPTION
The interactive setup wizard was stuck pre-M4, so **installing via the UI produced an SSH-only tunnel** (no TLS/mail arsenal) — the reason a UI-provisioned node showed `Endpoints: 0` and every pipe was `mimic=ssh`, while the non-interactive CLI (used in testing) worked. This also undercut anti-filtering for UI installs.

## Fix
- **Mimic selection at setup** via a checkbox (`survey.MultiSelect`); first option **`all`** = the whole arsenal, default `ssh+tls`.
  - Foreign builds `cfg.Mimics` on conventional ports (ssh=listen-port, tls=443, smtp=587, imap=143, smtps=465, imaps=993).
  - Iran builds `node.Endpoints` toward those ports.
  - SSH-only prompts (port / decoy / move-ssh) appear only when SSH is selected.
- **Observability:** each sub-pool's scale logs are labeled `pool=tcp|udp`, so the (already auto-warmed) **UDP sub-pool is visible** in journalctl. (It was there all along — the `max=6` lines — just unlabeled.)

## Tests
mimicPort / containsStr / allMimics-completeness. Full `-race` suite green; amd64+arm64 build clean. Version → **v0.7.2**.