### PR TITLE
v0.7.3 — fix Iran hub deadlock crash-loop with zero foreign nodes

### DIFF
--- a/cmd/hedioum/main.go
+++ b/cmd/hedioum/main.go
@@ -23,7 +23,7 @@ import (
 // so v0.5 and v0.6 nodes interoperate): structured slog logging, non-interactive
 // CLI + self-install, configurable decoy/listen ports, buffered banner reads, and
 // a ghp.ci-free, signature-free-but-robust self-update.
-const AppVersion = "v0.7.2"
+const AppVersion = "v0.7.3"
 
 func main() {
 	// Management subcommands (a non-flag first argument): install, setup-*, etc.

--- a/internal/egress/server.go
+++ b/internal/egress/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/mimic"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/securestream"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/sysutil"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/tlscert"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/tunproto"
 )
@@ -62,7 +63,7 @@ func StartForeignDaemon(cfg *config.AppConfig) {
 		go startHTTPDecoy(cfg.HTTPDecoyPort)
 	}
 
-	select {} // block forever
+	sysutil.WaitForTerminationSignal() // block until terminated (see helper)
 }
 
 // startHTTPDecoy binds a plaintext port (default 80) and answers every connection

--- a/internal/ingress/hub.go
+++ b/internal/ingress/hub.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/pool"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/sysutil"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/tunproto"
 )
 
@@ -29,8 +30,14 @@ func StartIranHub(cfg *config.AppConfig) {
 		go startLocalSocksListener(nodeCopy, hubManager)
 	}
 
-	// Block the main thread to keep daemons running indefinitely.
-	select {}
+	if len(cfg.ForeignNodes) == 0 {
+		slog.Warn("iran hub started with no foreign nodes; add a node and restart")
+	}
+
+	// Block until terminated. Not a bare select{}: with zero nodes there are no
+	// other goroutines, and select{} would trip the runtime's deadlock detector
+	// and crash-loop the service.
+	sysutil.WaitForTerminationSignal()
 }
 
 // startLocalSocksListener boots up a TCP server listening exclusively on 127.0.0.1.

--- a/internal/sysutil/wait.go
+++ b/internal/sysutil/wait.go
@@ -1,0 +1,18 @@
+package sysutil
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// WaitForTerminationSignal blocks until the process receives SIGINT or SIGTERM.
+// Daemons use it instead of a bare `select{}` so the process stays alive even when
+// it has no active goroutines (e.g. an Iran hub configured with zero foreign
+// nodes) — a bare `select{}` there trips Go's runtime deadlock detector and
+// crash-loops the service. It also enables a clean shutdown under systemd.
+func WaitForTerminationSignal() {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+}


### PR DESCRIPTION
## Bug
An Iran hub configured with **zero foreign nodes** (e.g. right after removing the last node in the dashboard) crash-loops:
```
fatal error: all goroutines are asleep - deadlock!
ingress.StartIranHub(...) hub.go:33   ← select {}
```
With no nodes, the setup loop spawns no goroutines, so the trailing `select{}` is the only goroutine and Go's runtime deadlock detector aborts the process; systemd then restart-loops it.

## Fix
Block on `SIGINT`/`SIGTERM` via `sysutil.WaitForTerminationSignal()` instead of a bare `select{}`. The signal-watcher goroutine keeps the process out of the deadlock detector (so a node-less hub stays up for reconfiguration) and gives a clean shutdown under systemd. Applied to both the hub and egress daemons; the hub also warns when it starts with no nodes.

Verified: a zero-node hub as the sole goroutine now blocks cleanly instead of crashing. Full `-race` suite green. Version → **v0.7.3**.