### PR TITLE
v0.7.4 — --mimics all = whole arsenal + setup-foreign applies immediately

### DIFF
--- a/cmd/hedioum/cli_test.go
+++ b/cmd/hedioum/cli_test.go
@@ -42,8 +42,8 @@ func TestValidTarget(t *testing.T) {
 }
 
 func TestExpandMimics(t *testing.T) {
-	if got, _ := expandMimics("all"); len(got) != 2 || got[0] != "ssh" || got[1] != "tls" {
-		t.Fatalf("all => %v", got)
+	if got, _ := expandMimics("all"); len(got) != 6 || got[0] != "ssh" || got[5] != "imaps" {
+		t.Fatalf("all => %v (want all 6 mimics)", got)
 	}
 	if got, _ := expandMimics("tls"); len(got) != 1 || got[0] != "tls" {
 		t.Fatalf("tls => %v", got)

--- a/cmd/hedioum/main.go
+++ b/cmd/hedioum/main.go
@@ -23,7 +23,7 @@ import (
 // so v0.5 and v0.6 nodes interoperate): structured slog logging, non-interactive
 // CLI + self-install, configurable decoy/listen ports, buffered banner reads, and
 // a ghp.ci-free, signature-free-but-robust self-update.
-const AppVersion = "v0.7.3"
+const AppVersion = "v0.7.4"
 
 func main() {
 	// Management subcommands (a non-flag first argument): install, setup-*, etc.

--- a/cmd/hedioum/setup_cmd.go
+++ b/cmd/hedioum/setup_cmd.go
@@ -14,9 +14,12 @@ import (
 )
 
 // expandMimics turns "all" or a comma list into an ordered, validated mimic list.
+// "all" means the whole arsenal — the same as the interactive wizard's "all"
+// checkbox, so CLI and wizard agree (a mismatch left the two ends of a link on
+// different mimic sets).
 func expandMimics(spec string) ([]string, error) {
 	if spec == "all" {
-		return []string{"ssh", "tls"}, nil
+		return []string{"ssh", "tls", "smtp", "imap", "smtps", "imaps"}, nil
 	}
 	var out []string
 	for _, p := range strings.Split(spec, ",") {
@@ -141,6 +144,9 @@ func cmdSetupForeign(args []string) {
 	}
 	color.Green("[✓] Foreign config written (mimics: %s, egress %s).", strings.Join(types, ","), *egressMode)
 	fmt.Printf("Auth Token: %s\n", tok)
+	// Apply immediately: without a restart the daemon keeps its old config (old
+	// mimics AND old token), which silently breaks the link after re-provisioning.
+	restartDaemon()
 }
 
 // cmdSetupIran writes the Iran (hub) config with its first node.


### PR DESCRIPTION
Two setup bugs found on a live re-provision:

1. **`--mimics all` disagreed with the wizard.** CLI `expandMimics("all")` returned `ssh,tls`, but the wizard "all" checkbox enables all six. A wizard-configured hub (6 endpoints) pointed at a CLI-configured foreign (`--mimics all` = ssh,tls) timed out on smtp/imap/smtps/imaps. Now both mean the whole arsenal.
2. **`setup-foreign` did not restart the daemon.** It wrote the config (new mimics AND a freshly generated token) but the running daemon kept the old config — so the token silently diverged from the hub, surfacing as `securestream: authentication failed`. It now restarts like `add-node`/`remove-node`.

Version → **v0.7.4**.