### PR TITLE
Add censorship-audit expert skill (DPI/anti-filtering audit + hardening)

### DIFF
--- a/.claude/skills/censorship-audit/SKILL.md
+++ b/.claude/skills/censorship-audit/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: censorship-audit
+description: >-
+  Audit and harden the Hedioum Pool Tunnel against nation-state DPI and
+  censorship, as a filtering/anti-censorship expert would. Covers the tunnel's
+  on-wire footprint, fingerprintability (TLS/JA3-JA4, SSH, entropy, timing),
+  active-probe resistance, real-connection-vs-mimic differences, firewall
+  exposure, and the exact conditions under which a censor could discover the
+  tunnel or the servers — then prescribes hardening that lowers detectability
+  without wrecking throughput. Use whenever the task involves filtering
+  resistance, DPI/SNI/JA3 evasion, tunnel footprint/traces, "why did this server
+  get blocked or throttled", active probing, decoy realism, or making the tunnel
+  harder to find, trace, or fingerprint.
+---
+
+# Hedioum Censorship & DPI Audit
+
+You are a **dual-hat censorship expert**: first the **red team** (a state DPI
+operator — Iran's DPI, the GFW — trying to discover, fingerprint, throttle, or
+block this tunnel), then the **blue team** (the maintainer hardening it). Never
+hand-wave. Ground every claim in (a) what a censor can actually observe or do,
+(b) the *specific* Hedioum code path that produces the observable, and (c) a
+concrete test or capture. When you can reach the servers, **measure — don't
+theorize**: capture packets, extract fingerprints, and run active probes.
+
+Two rules the whole skill serves:
+1. **Stealth is about looking like something allowed, not about looking like
+   nothing.** Fully-random / fully-encrypted traffic is itself a signature.
+2. **Every stealth change has a throughput/UX cost.** Always state the trade-off;
+   the goal is *undetectable AND fast*, not stealth at any cost.
+
+Read `references/threat-model.md` for the detailed censor capability model and
+`references/hardening-playbook.md` for the prioritized fix roadmap. This file is
+the operating method + the Hedioum-specific weakness map.
+
+---
+
+## 1. The censor's toolbox (what you are defending against)
+
+- **Passive fingerprinting.** TLS ClientHello/ServerHello (JA3/JA4), cert chain,
+  SNI, ALPN, SSH banners + KEX, packet sizes, inter-arrival timing, flow
+  duration, direction ratios, and per-IP connection counts.
+- **Fully-encrypted-traffic heuristics.** Modern DPI (GFW since Nov 2021, mirrored
+  in Iran) does **not** try to decrypt — it *exempts* flows that look like a known
+  protocol and blocks the rest. Exemption heuristics operate on the **first ~6
+  bytes**: fraction of set bits (`popcount ≈ 50%` ⇒ looks random ⇒ suspicious),
+  and the count/fraction/position of **printable ASCII**. A handshake that begins
+  with high-entropy random bytes trips this. (USENIX Security '23, gfw.report.)
+- **Active probing.** The censor connects to your port and speaks the protocol it
+  expects (HTTP to :443, SSH to :22, STARTTLS to :587), or replays a captured
+  handshake, and watches whether the server behaves like the real service or
+  reveals a proxy (wrong cert, closes oddly, high-entropy reply, no valid
+  response). High-entropy probe *responses* are a fast block trigger.
+- **Residual signals.** Datacenter/ASN reputation, geo, and correlation across
+  many users hitting the same foreign IP.
+
+Cite the primary sources when you report: the GFW fully-encrypted paper
+(gfw.report / USENIX Security '23) and XTLS/REALITY for the state of the art.
+
+---
+
+## 2. Hedioum's detection surface — component by component
+
+For each mimic, know *exactly* what appears on the wire and where in the code it
+comes from. (Paths are in `internal/mimic/`, `internal/securestream/`,
+`internal/pool/`.)
+
+### SSH mimic (`ssh.go`) — port 22
+- **On the wire:** a real `SSH-2.0-...` banner (byte-for-byte mirror of the host's
+  own sshd), then the `securestream` handshake (random salt + ChaCha20-Poly1305
+  ciphertext), then yamux.
+- **Why the banner helps:** printable-ASCII start ⇒ *exempted* by the
+  fully-encrypted heuristic, and the later high-entropy payload matches real SSH.
+- **The real weaknesses:**
+  - **Nobody opens 10–20 parallel SSH sessions to one foreign IP.** The
+    `internal/pool` warm-up (`min_connections`) is a glaring anomaly — real SSH is
+    1 long session. This is the SSH mimic's biggest tell (traffic analysis, not DPI).
+  - **Outbound :22 to a random foreign datacenter IP** is rare from Iran and is
+    frequently throttled/blocked wholesale (see community issue "port 22 filtered").
+  - The securestream handshake after the banner never completes a *real* SSH KEX —
+    an active prober that speaks SSH-2.0 KEXINIT is routed to the **decoy sshd**
+    (good), but the *timing/behaviour* of that redirect can differ from a native
+    sshd. Verify the decoy is byte- and timing-faithful.
+
+### TLS/HTTPS mimic (`tls.go`, `tlsauth.go`) — port 443
+- **On the wire:** a **real** TLS 1.2/1.3 handshake, then application data (the
+  channel-bound auth `HEDIOTLS…` magic + HMAC, then yamux) — all **inside** TLS,
+  so the magic is *not* visible on the wire. Client uses **uTLS
+  `HelloChrome_Auto`** ⇒ a real Chrome JA3/JA4.
+- **Why it hides well from the entropy heuristic:** the flow starts with a valid
+  TLS record (`0x16 0x03…`), so it is exempted like any HTTPS.
+- **The real weaknesses (this is where a censor wins):**
+  - **Self-signed certificate.** `tlscert.LoadOrCreate` issues an ECDSA P-256 cert
+    with CN = server name or `localhost`. **Real HTTPS sites present a CA-signed
+    cert for a real domain.** An active probe (or passive cert capture) sees a
+    self-signed cert on a bare datacenter IP with no SNI/domain ⇒ **high-confidence
+    proxy signal.** This is the single most important TLS finding. → REALITY or a
+    real domain + valid cert.
+  - **No real SNI / domain fronting.** Connections carry the server IP or a fake
+    SNI, not a real hostname the censor would allow.
+  - **uTLS drift.** `HelloChrome_Auto` must track the Chrome version the censor's
+    allow-list expects; a stale uTLS fingerprint is itself detectable. Check the
+    pinned uTLS version.
+  - **Decoy realism.** Unauthenticated peers get the built-in Apache page — but it
+    is **identical across every install**, so the exact bytes become a *fleet-wide*
+    signature. A prober comparing two Hedioum servers sees the same page.
+
+### STARTTLS SMTP/IMAP (`starttls.go`) — 587 / 143; implicit SMTPS/IMAPS — 465 / 993
+- **On the wire:** a plaintext mail prologue (`220 … ESMTP`, `EHLO`, `STARTTLS`)
+  then the TLS mimic. Implicit variants are pure TLS on 465/993.
+- **Weaknesses:** the prologue is a fixed, minimal script — a mail-savvy prober
+  (real `EHLO` capabilities, `MAIL FROM`, IMAP `CAPABILITY`) can tell it is not a
+  real MTA once inside TLS (the decoy is the web page, not a mail server). Same
+  self-signed-cert problem as the TLS mimic. Mail ports are also **more often
+  blocked/suspicious** from residential Iran than 443.
+
+### The connection pool (`internal/pool`) — the cross-cutting signature
+- **min→max fluctuating physical connections**, jittered keep-alives, per-conn
+  **fluctuating bandwidth caps** (Chaos Mesh). Individually clever, but as a set:
+  N simultaneous, long-lived, high-entropy flows to **one** foreign IP, scaling up
+  and down together, is a **strong traffic-analysis fingerprint** regardless of
+  which mimic wraps them. Analyse: connection count over time, establishment
+  timing correlation, flow-duration distribution, up/down byte ratios.
+
+### The securestream transport (`internal/securestream`)
+- ChaCha20-Poly1305 + HKDF keyed by the token; random salt prefix; per-frame
+  random padding (defeats fixed-size warm-up fingerprinting — good). The salt
+  prefix is high-entropy, but it rides **after** the SSH banner or **inside** TLS,
+  so it is not exposed to the first-byte heuristic — **confirm this is still true**
+  for every mimic before claiming safety.
+
+---
+
+## 3. Audit methodology (run this, in order)
+
+Prefer live measurement. Use the servers when available; otherwise reason from
+code + a local loopback reproduction.
+
+1. **Capture** on the foreign (public side) and the hub: `tcpdump -ni any -w`.
+   Separate the mimic control flows (TCP to the mimic port) from egress.
+2. **TLS fingerprint & cert** on :443 (and 465/993):
+   - `echo | openssl s_client -connect IP:443 -servername X` → read the cert:
+     issuer==subject and CN=localhost ⇒ **self-signed finding**. Check validity,
+     key type, SAN.
+   - Capture the **ServerHello + Certificate** and derive JA3S/JA4S; capture a
+     client handshake and derive JA3/JA4 (compare to a real Chrome).
+   - Note SNI, ALPN, TLS version, session-ticket behaviour.
+3. **Entropy / first-byte heuristic** (the GFW test): for each mimic, extract the
+   **first 6–16 bytes** the client sends and compute: fraction of set bits (flag
+   if ≈0.5) and printable-ASCII fraction/position (flag if too low). SSH banner and
+   TLS record header should keep you exempted — *prove it*.
+4. **Active probing** (be the censor):
+   - :443 → send `GET / HTTP/1.1` over TLS ⇒ must return the decoy page, not reset.
+   - :22 → real SSH client ⇒ must complete KEX via the decoy sshd (admin still
+     works), no anomaly.
+   - :587/:143 → speak SMTP/IMAP incl. `EHLO`/`CAPABILITY`+`STARTTLS` ⇒ must upgrade
+     (v0.7.2+) and not reveal a proxy.
+   - random 64 bytes → server must not crash and must respond plausibly.
+   - Replay a captured handshake ⇒ must be rejected (replay filter) **and** routed
+     to decoy, not error out (which itself is a signal).
+5. **Traffic analysis** of the pool: connection count vs time, establishment
+   inter-arrival, flow durations, packet-size histograms, direction ratios. Ask:
+   "does this look like a browser, an SSH session, or N-correlated tunnels?"
+6. **Fixed-signature sweep:** the Apache decoy bytes, cert CN, mail prologue
+   strings, any constant magic *visible on the wire* — anything identical across
+   installs is a fleet signature.
+7. **Exit reputation:** is the foreign IP a flagged datacenter range? Test the
+   Gemini/AI-Studio/OpenAI 403 signal (a proxy for "this IP is known-bad") and
+   ASN/geo. A clean pipe behind a burned IP still fails.
+
+Report each finding as: **observable → root cause (file:line) → censor action it
+enables → severity → fix**, most severe first.
+
+---
+
+## 4. Hedioum weakness map (current, severity-ranked)
+
+| # | Finding | Severity | Fix direction |
+|---|---------|:--------:|---------------|
+| 1 | **Self-signed cert on :443** (no real domain/SNI) — active/passive proxy tell | 🔴 High | REALITY (steal a real site's cert) OR real domain + Let's Encrypt |
+| 2 | **Pool = N correlated long-lived flows to one IP** — traffic-analysis signature | 🔴 High | Fewer/longer conns, decorrelated establishment, or multiplex more per pipe |
+| 3 | **SSH mimic on :22 to a foreign datacenter IP** — rare, throttled, anomalous pool | 🟠 Med | Prefer TLS:443; treat SSH as secondary; never the only/primary mimic |
+| 4 | **Identical Apache decoy across installs** — fleet-wide signature | 🟠 Med | Per-install decoy diversity; optional :80→:443 redirect; real backend |
+| 5 | **Datacenter exit IP reputation** — geo/AI blocks, easy ASN targeting | 🟠 Med | IP-reputation pre-check; residential/clean ranges; per-destination routing |
+| 6 | **uTLS Chrome fingerprint drift** — stale JA3 becomes detectable | 🟡 Low | Track uTLS/Chrome versions; verify pinned `HelloChrome_Auto` |
+| 7 | **Mail mimics reveal non-MTA behaviour under deep probe** | 🟡 Low | Only enable where mail is plausible; richer prologue; real mail decoy |
+
+Re-run the audit and update this table; do not treat it as static.
+
+---
+
+## 5. Hardening priorities (see `references/hardening-playbook.md`)
+
+In rough order of impact-per-effort for THIS project:
+1. **Kill the self-signed-cert tell:** add a REALITY-style handshake (proxy
+   unknown-SNI probes to a real target, borrow its cert) or real-domain + ACME.
+   This is the highest-leverage change.
+2. **CDN / WebSocket fronting** (VLESS+WS+TLS behind Cloudflare/ArvanCloud style):
+   hides the real foreign IP, uses the CDN's SNI, and sidesteps IP-reputation and
+   ASN targeting.
+3. **Shrink the pool signature:** decorrelate connection establishment, allow
+   fewer but longer-lived pipes, and prefer heavier per-pipe multiplexing over
+   many parallel TCP flows.
+4. **First-byte / entropy safety:** keep every mimic's first bytes protocol-shaped
+   (TLS record or ASCII banner). Never expose a raw high-entropy prefix.
+5. **Decoy diversity + realism:** rotate decoy templates per install; make the web
+   decoy respond to more paths/verbs like a real server.
+6. **Exit-IP hygiene:** a built-in `check-ip` (Gemini/OpenAI/ASN) before deploy;
+   domain/GeoIP split-routing so sensitive services use a clean exit.
+7. **Timing/padding shaping** *only if measured to help* — it costs latency and
+   throughput, so validate against a real trace before shipping.
+
+---
+
+## 6. Performance vs stealth — always state the trade-off
+
+The user's goal is **no speed/quality loss AND no blocking**. For every
+recommendation, quantify the cost:
+- REALITY/real-TLS: ~0 throughput cost, big stealth win. **Do first.**
+- CDN fronting: adds a hop (latency, and CDN bandwidth cost) but huge IP-hiding
+  win. Worth it for the control/handshake; may bypass for bulk if split.
+- Padding/timing obfuscation: real throughput/latency cost — only if a trace shows
+  a timing/size signature that actually gets you blocked.
+- Fewer pool connections: lower parallelism can cap peak Mbps — balance against the
+  16MB-window + BBR single-pipe throughput already available.
+
+Never recommend a stealth change without naming what it costs and how to verify it
+was worth it (before/after capture + a real speedtest through the tunnel).

--- a/.claude/skills/censorship-audit/references/hardening-playbook.md
+++ b/.claude/skills/censorship-audit/references/hardening-playbook.md
@@ -1,0 +1,139 @@
+# Hardening playbook — lowering detectability without wrecking speed
+
+Reference for the `censorship-audit` skill. Ordered by impact-per-effort for the
+Hedioum codebase. Each item: **what, why, how (in Hedioum terms), cost, verify.**
+
+---
+
+## 1. Remove the self-signed-cert tell — REALITY or real-domain TLS  🔴 highest leverage
+
+**Why:** the #1 passive/active signal today is a self-signed cert on a bare IP with
+no real SNI. Every serious modern circumvention transport solves exactly this.
+
+**Two options:**
+- **REALITY-style** (preferred; no domain needed): on the TLS mimic, when a peer
+  connects with an unexpected/absent SNI or fails auth, **proxy the TLS handshake
+  to a real allow-listed site** (e.g. a big CDN host) so the prober gets that
+  site's *genuine* cert and page; only real clients (who know the short-id/token)
+  get tunneled. This borrows a real cert and defeats the SNI-mismatch probe.
+  Requires TLS 1.3 and matching the target's ALPN. Touch points:
+  `internal/mimic/tls.go` (handshake handling + decoy routing), a new
+  "borrowed-cert" path replacing `tlscert.LoadOrCreate` for probes.
+- **Real domain + ACME:** let the operator set a domain; fetch a Let's Encrypt cert
+  (auto, no manual step) so :443 presents a CA-signed cert for a real hostname.
+  Simpler, but exposes a domain (CT logs) and needs DNS.
+
+**Cost:** ~0 throughput. Implementation complexity is the only cost.
+**Verify:** SNI-mismatch probe now returns a real cert; JA3S/cert no longer flags.
+
+---
+
+## 2. CDN / WebSocket fronting  🔴
+
+**Why:** hides the real foreign IP entirely (censor sees only the CDN edge + the
+CDN's SNI), sidesteps IP/ASN reputation and geo blocks, and inherits the CDN's
+"too big to block" property. This is the danyarai.ir-style setup users already run
+in front of Hedioum.
+
+**How (Hedioum terms):** add a **VLESS/WS+TLS-style transport option** so a mimic
+can run as WebSocket-over-TLS behind a CDN, or document/first-class the
+"CDN → panel → Hedioum SOCKS" chain. A new mimic transport in `internal/mimic/`
+that speaks WS.
+
+**Cost:** one extra hop (latency + CDN bandwidth $$). Often used for control/light
+traffic with a direct bulk path via split-routing.
+**Verify:** the real foreign IP never appears in a client-side capture; SNI = CDN.
+
+---
+
+## 3. Shrink the connection-pool signature  🔴/🟠
+
+**Why:** N correlated long-lived flows to one IP is a mimic-independent
+traffic-analysis fingerprint (see threat-model A4).
+
+**How:**
+- **Decorrelate establishment:** the pool already staggers (`staggerDelay`) and
+  jitters keep-alives — increase/ randomize the warm-up spread so SYNs don't burst.
+- **Fewer, fatter pipes:** lean on yamux multiplexing + the 16MB window + BBR so
+  one pipe carries more, reducing parallel-flow count. Lower default
+  `min_connections`; scale up only under real load.
+- **Vary per-install:** the Chaos-Mesh fluctuating distribution already makes two
+  installs differ — extend it to pool *size/shape*, not just mimic mix.
+
+**Cost:** fewer pipes can cap burst parallelism; balance against single-pipe
+throughput (already high). Measure peak Mbps before/after.
+**Verify:** connection-count-over-time and SYN-burst correlation look like a
+browser/CDN client, not N tunnels.
+
+---
+
+## 4. First-byte / entropy safety (keep the exemption)  🟠
+
+**Why:** the fully-encrypted heuristic blocks random-looking prefixes. Hedioum is
+currently exempt (ASCII banner / TLS record first), but this is a *property to
+protect*, not assume.
+
+**How:** add a regression test/assertion that every mimic's first client bytes are
+either a valid TLS record (`0x16 0x03`) or printable-ASCII, and that securestream's
+random salt is never the first thing on the wire. Consider a small ASCII/protocol
+preamble for any future raw-transport mimic.
+**Cost:** ~0. **Verify:** popcount ≈ 0.5 test on the first 6 bytes must *fail*
+(i.e. not look random) for every mimic.
+
+---
+
+## 5. Decoy diversity + realism  🟠
+
+**Why:** the identical built-in Apache page is a fleet-wide signature; a shallow
+decoy fails a determined prober.
+
+**How:** ship several decoy templates (nginx/Apache/Caddy/IIS defaults) and pick
+per-install (seeded by token) — the same idea as the mimic-distribution Chaos Mesh.
+Optionally serve a real backend, or a plausible :80→:443 redirect. Make the web
+decoy answer more paths/verbs like a real server. Touch: `internal/mimic/webdecoy.go`.
+**Cost:** ~0. **Verify:** two installs serve *different* decoy bytes; probing more
+paths still looks like a normal server.
+
+---
+
+## 6. Exit-IP hygiene  🟠
+
+**Why:** a perfectly stealthy pipe behind a burned datacenter IP still fails
+(Google-AI 403, ASN blocks). Cheap "unlimited" hosts recycle flagged ranges.
+
+**How:**
+- A built-in **`check-ip`** command: from the foreign, test Gemini/AI-Studio/OpenAI
+  reachability + ASN/geo, and warn if the IP is flagged (the diagnostic already
+  used ad-hoc in this project). Run before/at deploy.
+- **Domain/GeoIP split-routing** in the SOCKS layer (it already sees the domain):
+  send sensitive/AI traffic out a clean exit, bulk out a cheap one; keep `.ir` /
+  Iran-GeoIP direct.
+- Prefer residential/clean ranges for the primary exit; multi-node failover.
+**Cost:** operational (choosing hosts). **Verify:** `check-ip` passes; AI services
+return 200 through the tunnel.
+
+---
+
+## 7. uTLS / fingerprint maintenance  🟡
+
+Track the uTLS library and the Chrome version its `HelloChrome_Auto` emulates;
+a stale JA3 becomes a fingerprint. Add a note/CI check to bump uTLS periodically.
+**Cost:** ~0. **Verify:** JA3/JA4 matches a current mainstream Chrome.
+
+---
+
+## 8. Timing / padding shaping  🟡 — only if measured
+
+Traffic-shaping to mimic HTTPS timing/size *can* help against A4, but it costs
+latency and throughput. **Do not add speculatively.** Only ship it if a real trace
+shows a timing/size signature that actually triggers blocking, and re-measure a
+real speedtest through the tunnel after.
+
+---
+
+## Cross-cutting rule
+
+Pair every change with a **before/after**: a packet capture (fingerprint/probe
+result) *and* a throughput/latency measurement through the full tunnel. Stealth
+that halves the user's speed is not a win. The north star is **indistinguishable
+from allowed traffic, at full speed.**

--- a/.claude/skills/censorship-audit/references/threat-model.md
+++ b/.claude/skills/censorship-audit/references/threat-model.md
@@ -1,0 +1,96 @@
+# Threat model — what a nation-state censor can actually do
+
+A reference for the `censorship-audit` skill. Assume a censor with the
+capabilities of Iran's DPI or the GFW: line-rate passive inspection on backbone
+links, a fleet of active probers, per-IP/ASN state, and the willingness to block
+by IP, SNI, port, or protocol-heuristic. Everything below is a *capability the
+adversary has*, mapped to how it bites Hedioum.
+
+## A. Passive fingerprinting (no interaction)
+
+### A1. TLS fingerprinting (JA3 / JA4 / JA3S / JA4S)
+- The ClientHello (cipher suites, extensions, curves, ALPN, order) hashes to a
+  **JA3/JA4** fingerprint. A Go-crypto/tls ClientHello is instantly non-browser.
+  Hedioum uses **uTLS `HelloChrome_Auto`** ⇒ matches Chrome — good, *if current*.
+- The **ServerHello + Certificate** hash to **JA3S/JA4S** and expose the cert.
+  This is where Hedioum leaks: a **self-signed cert** (issuer==subject, CN often
+  `localhost`) on a bare IP with **no real SNI** is not what any real HTTPS site
+  presents. Passive cert capture alone is enough to flag it.
+- **Mitigation reality:** only REALITY (borrow a real site's live cert) or a real
+  domain + CA cert removes this. uTLS fixes the *client* half; it does nothing for
+  the *server* cert.
+
+### A2. The fully-encrypted-traffic heuristic (GFW, Nov 2021 →; mirrored in Iran)
+- The censor does **not** decrypt. It **exempts** flows that look like a known
+  protocol and blocks the rest. Exemption tests run on the **first ~6 bytes**:
+  - **Ex1 — popcount:** if the fraction of set bits is ≈ 0.5 (looks random),
+    *not* exempted.
+  - **Ex2–Ex5 — printable ASCII:** enough printable-ASCII bytes, or a known
+    protocol prefix (HTTP verbs, TLS record, SSH banner), ⇒ exempted.
+- **Implication for Hedioum:** a raw high-entropy prefix would get blocked. Hedioum
+  is currently safe because every mimic's first bytes are protocol-shaped: SSH
+  sends `SSH-2.0-…` (ASCII), TLS sends a `0x16 0x03` record. **The audit must
+  re-verify this for every code path** — any mimic that ever emits a random prefix
+  before an ASCII/TLS envelope is immediately blockable.
+- Source: "How the GFW Detects and Blocks Fully Encrypted Traffic", USENIX
+  Security 2023 (gfw.report/publications/usenixsecurity23).
+
+### A3. SSH fingerprinting
+- Banner string, KEXINIT algorithm list/order, packet sizing. Hedioum mirrors the
+  host banner (good) but the pool behaviour (below) betrays it anyway.
+
+### A4. Traffic analysis (the hardest to hide, mimic-independent)
+- **Connection count to one IP over time.** A browser opens a handful of short
+  flows to *many* IPs. Hedioum opens **N long-lived flows to one** foreign IP and
+  scales N up/down. That shape is unusual for any single legitimate app.
+- **Establishment timing correlation:** pool warm-up dials several pipes within
+  seconds — correlated SYN bursts to one IP.
+- **Flow duration & byte-ratio:** tunnels are long-lived and roughly symmetric or
+  download-heavy in a steady way; the fluctuating-cap jitter helps but the
+  *aggregate* is still analysable.
+- **Packet-size distribution:** securestream per-frame padding helps; yamux
+  framing + 16MB windows produce their own distribution — compare to real HTTPS.
+
+### A5. QUIC / UDP
+- Since Apr 2024 the GFW decrypts QUIC Initial packets for SNI-based blocking.
+  Hedioum tunnels UDP over TCP (no UDP on the inter-node wire), so this does not
+  hit the tunnel directly — but a client that leaks QUIC *outside* the tunnel is
+  exposed.
+
+## B. Active probing (the censor connects to you)
+
+- **Protocol-speak probes:** HTTP to :443, SSH to :22, EHLO/STARTTLS to :587. The
+  server must respond exactly like the real service. Hedioum routes these to
+  decoys — verify byte- and timing-fidelity, and that a wrong-token/replayed
+  handshake is **routed to decoy, not errored** (an error or reset is itself a
+  signal).
+- **SNI-mismatch probe (the REALITY test):** connect with an unexpected SNI. A real
+  fronting setup forwards to the real site and returns its cert. Hedioum's TLS
+  mimic returns *its own* self-signed cert regardless of SNI ⇒ detectable.
+- **Entropy probe:** send `/dev/urandom`; a high-entropy *reply* is a fast block
+  trigger. Hedioum's decoys reply with ASCII (HTTP/SSH) — good — but confirm no
+  path replies with raw ciphertext to an unauthenticated peer.
+- **Replay probe:** capture a real client handshake and replay it. Must be dropped
+  by the replay filter *and* handled like a decoy.
+
+## C. Residual / out-of-band signals
+
+- **IP/ASN reputation & geo:** datacenter ranges (OVH, cheap "unlimited" hosts) are
+  pre-flagged; Google AI / OpenAI 403s are a cheap proxy for "known-bad exit".
+- **Cross-user correlation:** many Iranian users hitting one foreign IP, or one
+  `danyarai.ir`-style CDN edge, concentrates signal.
+- **Certificate transparency / scanning:** a real domain with a valid cert is
+  logged in CT; a bare IP with a self-signed cert stands out to internet-wide
+  scanners (Censys/Shodan-style) that censors also run.
+
+## D. What Hedioum already does right (don't "fix" these)
+
+- Real TLS handshake + uTLS Chrome ClientHello (A1 client half, A2 exemption).
+- ASCII SSH banner before ciphertext (A2 exemption for the SSH path).
+- Per-frame random padding (A4 size fingerprinting).
+- Decoy routing for unauthorized/replayed probes (B), incl. mirrored sshd banner.
+- Channel-bound auth *inside* TLS — the `HEDIOTLS` magic is never on the wire.
+- AEAD (ChaCha20-Poly1305 + HKDF), token never transmitted.
+
+The audit's job is to attack everything else — chiefly the **self-signed cert**
+(A1/B), the **pool traffic shape** (A4), and **exit-IP reputation** (C).


### PR DESCRIPTION
Adds a specialized English **skill** at `.claude/skills/censorship-audit/` that makes the assistant a dual-hat DPI / anti-censorship expert for auditing and hardening the tunnel.

**Contents**
- `SKILL.md` — operating method: the censor's toolbox, Hedioum's detection surface per mimic (with code refs), a runnable audit methodology (packet capture, TLS/JA3+JA4 & cert, the GFW first-byte entropy heuristic, active probing, traffic analysis, fixed-signature sweep, exit-IP reputation), a severity-ranked weakness map, and explicit performance-vs-stealth trade-offs.
- `references/threat-model.md` — the censor capability model, grounded in the USENIX Security '23 GFW fully-encrypted-traffic paper and XTLS/REALITY.
- `references/hardening-playbook.md` — prioritized fixes (REALITY / real-cert, CDN-WS fronting, pool-signature reduction, entropy safety, decoy diversity, exit-IP hygiene), each with cost and before/after verification.

**Top findings it surfaces:** the self-signed cert on :443 (highest-leverage tell), the correlated connection-pool traffic shape, and datacenter exit-IP reputation.

Docs only — no code/build impact.