### PR TITLE
Coherent server personas (M2)

### DIFF
--- a/cmd/hedioum/dashboard.go
+++ b/cmd/hedioum/dashboard.go
@@ -97,6 +97,11 @@ func runInteractiveDashboard(cfg *config.AppConfig) {
 			} else if cfg.Role == "foreign" {
 				// Display critical connection info for the foreign server
 				color.HiCyan("\n=== [ Egress Node Details ] ===")
+				personaLabel := cfg.Persona
+				if personaLabel == "" {
+					personaLabel = "custom"
+				}
+				fmt.Printf(" ├─ Persona     : %s (%d mimics)\n", personaLabel, len(cfg.Mimics))
 				fmt.Printf(" ├─ Listen Port : %d\n", cfg.ForeignListenPort)
 				fmt.Printf(" └─ Auth Token  : %s\n", color.HiYellowString(cfg.AuthToken))
 				color.HiBlack("    (Use this token when configuring your Iran Hub)")

--- a/cmd/hedioum/edit_cmd.go
+++ b/cmd/hedioum/edit_cmd.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/persona"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/sysutil"
 )
 
@@ -169,7 +170,8 @@ func cmdEditForeign(args []string) {
 	}
 
 	fs := flag.NewFlagSet("edit-foreign", flag.ExitOnError)
-	mimics := fs.String("mimics", mimicTypesCSV(cfg.Mimics), "camouflage set (comma list or 'all')")
+	personaFlag := fs.String("persona", cfg.Persona, "server persona: auto|cpanel|directadmin|devops (re-resolves the mimic set)")
+	mimics := fs.String("mimics", mimicTypesCSV(cfg.Mimics), "explicit camouflage set (overrides --persona): comma list or 'all'")
 	sshPort := fs.Int("listen-port", ports["ssh"], "SSH mimic public port")
 	tlsPort := fs.Int("tls-port", ports["tls"], "TLS mimic public port")
 	smtpPort := fs.Int("smtp-port", ports["smtp"], "SMTP (STARTTLS) mimic public port")
@@ -188,6 +190,8 @@ func cmdEditForeign(args []string) {
 	token := fs.String("token", "", "set a specific new auth token (default: keep current)")
 	rotateToken := fs.Bool("rotate-token", false, "generate a fresh auth token")
 	_ = fs.Parse(args)
+	setFlags := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) { setFlags[f.Name] = true })
 
 	switch *decoyStyle {
 	case "apache", "directadmin":
@@ -204,13 +208,49 @@ func cmdEditForeign(args []string) {
 			fail("--egress-bind-ip: %v", err)
 		}
 	}
-	types, err := expandMimics(*mimics)
+	newToken, tokenNote, err := resolveTokenEdit(cfg.AuthToken, *token, *rotateToken)
 	if err != nil {
-		fail("--mimics: %v", err)
+		fail("--token: %v", err)
 	}
+
+	// Decide the mimic set. An explicit --mimics wins (custom, clears the persona);
+	// else an explicit --persona re-resolves from the (possibly rotated) token; else
+	// keep the current persona (re-resolved, so it tracks port/token edits) or the
+	// current custom set.
+	var types []string
+	switch {
+	case setFlags["mimics"]:
+		if types, err = expandMimics(*mimics); err != nil {
+			fail("--mimics: %v", err)
+		}
+		cfg.Persona = ""
+		if cerr := persona.CheckCoherence(types); cerr != nil {
+			color.Yellow("[!] %v (an explicit --mimics set — proceeding anyway).", cerr)
+		}
+	case setFlags["persona"]:
+		name := *personaFlag
+		if name == "auto" || name == "" {
+			name = persona.Auto(newToken)
+		} else if !persona.Known(name) {
+			fail("--persona must be auto|%s", strings.Join(persona.Names(), "|"))
+		}
+		if types, err = persona.Resolve(name, newToken); err != nil {
+			fail("--persona: %v", err)
+		}
+		cfg.Persona = name
+	case cfg.Persona != "":
+		if types, err = persona.Resolve(cfg.Persona, newToken); err != nil {
+			fail("--persona: %v", err)
+		}
+	default:
+		if types, err = expandMimics(*mimics); err != nil {
+			fail("--mimics: %v", err)
+		}
+	}
+
 	portMap := map[string]int{"ssh": *sshPort, "tls": *tlsPort, "smtp": *smtpPort, "imap": *imapPort, "smtps": *smtpsPort, "imaps": *imapsPort, "directadmin": *daPort}
-	// New-arsenal mimics (https-alt/docker/postgres/mysql) keep their resolved port
-	// (conventional default or the value already pinned in config); no extra flags.
+	// New-arsenal mimics keep their resolved port (conventional default or the value
+	// already pinned in config); no extra flags.
 	for _, ty := range []string{"https-alt", "docker", "grafana", "prometheus", "cpanel", "whm", "webmail", "postgres", "mysql"} {
 		portMap[ty] = ports[ty]
 	}
@@ -218,11 +258,6 @@ func cmdEditForeign(args []string) {
 		if err := validPort(p); err != nil {
 			fail("--%s-port: %v", label, err)
 		}
-	}
-
-	newToken, tokenNote, err := resolveTokenEdit(cfg.AuthToken, *token, *rotateToken)
-	if err != nil {
-		fail("--token: %v", err)
 	}
 
 	cfg.Mimics = buildForeignMimicList(types, portMap, *decoyPort, *tlsServerName)

--- a/cmd/hedioum/persona_wiring_test.go
+++ b/cmd/hedioum/persona_wiring_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/persona"
+)
+
+// TestPersonasUseValidMimics guarantees every persona resolves to mimic types the CLI
+// actually knows and can assign a port to — so a persona can never reference a mimic
+// that isn't in the library.
+func TestPersonasUseValidMimics(t *testing.T) {
+	for _, name := range persona.Names() {
+		set, err := persona.Resolve(name, "wiring-"+name)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		for _, m := range set {
+			if !validMimicType(m) {
+				t.Errorf("persona %s references unknown mimic %q", name, m)
+			}
+			if mimicPort(m, 22) == 0 {
+				t.Errorf("persona %s mimic %q has no port mapping", name, m)
+			}
+		}
+	}
+}

--- a/cmd/hedioum/setup_cmd.go
+++ b/cmd/hedioum/setup_cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/persona"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/sysutil"
 )
 
@@ -88,7 +89,8 @@ func cmdSetupForeign(args []string) {
 	pgPort := fs.Int("postgres-port", 5432, "PostgreSQL (STARTTLS) mimic port")
 	mysqlPort := fs.Int("mysql-port", 3306, "MySQL/MariaDB (STARTTLS) mimic port")
 	tlsServerName := fs.String("tls-servername", "", "TLS SNI/CN (optional)")
-	mimics := fs.String("mimics", "ssh", "camouflage: ssh|tls|https-alt|smtp|imap|smtps|imaps|directadmin|docker|postgres|mysql|all or a comma list")
+	personaFlag := fs.String("persona", "auto", "server persona: auto|cpanel|directadmin|devops (picks a coherent SSH+9 mimic set)")
+	mimics := fs.String("mimics", "", "explicit camouflage set (overrides --persona): comma list or 'all'")
 	domain := fs.String("domain", "", "real domain for a Let's Encrypt cert (recommended; empty = self-signed)")
 	acmeEmail := fs.String("acme-email", "", "Let's Encrypt account email (optional)")
 	decoyStyle := fs.String("decoy-style", "apache", "camouflage persona: apache|directadmin")
@@ -120,15 +122,37 @@ func cmdSetupForeign(args []string) {
 			fail("--egress-bind-ip: %v", err)
 		}
 	}
-	types, err := expandMimics(*mimics)
-	if err != nil {
-		fail("--mimics: %v", err)
-	}
 	tok := *token
 	if tok == "" {
 		tok = sysutil.GenerateSecureToken()
 	} else if err := validToken(tok); err != nil {
 		fail("--token: %v", err)
+	}
+
+	// Choose the mimic set: an explicit --mimics wins (power user); otherwise resolve
+	// a coherent persona (SSH + 9), seeded from the token so the set is deterministic
+	// per server and spreads across personas fleet-wide.
+	var types []string
+	var chosenPersona string
+	if *mimics != "" {
+		var err error
+		if types, err = expandMimics(*mimics); err != nil {
+			fail("--mimics: %v", err)
+		}
+		if cerr := persona.CheckCoherence(types); cerr != nil {
+			color.Yellow("[!] %v (an explicit --mimics set — proceeding anyway).", cerr)
+		}
+	} else {
+		chosenPersona = *personaFlag
+		if chosenPersona == "auto" || chosenPersona == "" {
+			chosenPersona = persona.Auto(tok)
+		} else if !persona.Known(chosenPersona) {
+			fail("--persona must be auto|%s", strings.Join(persona.Names(), "|"))
+		}
+		var err error
+		if types, err = persona.Resolve(chosenPersona, tok); err != nil {
+			fail("--persona: %v", err)
+		}
 	}
 
 	var mimicList []config.MimicListener
@@ -228,10 +252,14 @@ func cmdSetupForeign(args []string) {
 		EgressIPMode:      *egressMode,
 		EgressBindIP:      *bindIP,
 		AuthToken:         tok,
+		Persona:           chosenPersona,
 		Mimics:            mimicList,
 	}
 	if err := config.SaveConfig(cfg); err != nil {
 		fail("failed to save config: %v", err)
+	}
+	if chosenPersona != "" {
+		color.Green("[✓] Persona: %s (SSH backbone + %d coherent mimics).", chosenPersona, len(types)-1)
 	}
 	color.Green("[✓] Foreign config written (mimics: %s, egress %s).", strings.Join(types, ","), *egressMode)
 	if *domain == "" {

--- a/cmd/hedioum/setup_cmd.go
+++ b/cmd/hedioum/setup_cmd.go
@@ -284,7 +284,8 @@ func cmdAddNode(args []string) {
 	alias := fs.String("alias", "", "node alias")
 	targetIP := fs.String("target-ip", "", "foreign IP (with --mimics)")
 	target := fs.String("target", "", "single foreign HOST:PORT (legacy, SSH)")
-	mimics := fs.String("mimics", "", "endpoints: ssh|tls|all (needs --target-ip)")
+	personaFlag := fs.String("persona", "", "match the foreign's persona: auto|cpanel|directadmin|devops (derives the endpoint set from the token; needs --target-ip)")
+	mimics := fs.String("mimics", "", "explicit endpoint set (overrides --persona): comma list or 'all' (needs --target-ip)")
 	sshPort := fs.Int("ssh-port", 22, "foreign SSH mimic port")
 	tlsPort := fs.Int("tls-port", 443, "foreign TLS mimic port")
 	smtpPort := fs.Int("smtp-port", 587, "foreign SMTP (STARTTLS) mimic port")
@@ -323,13 +324,30 @@ func cmdAddNode(args []string) {
 
 	var endpoints []config.Endpoint
 	switch {
-	case *mimics != "":
+	case *mimics != "" || *personaFlag != "":
 		if *targetIP == "" {
-			fail("--mimics requires --target-ip")
+			fail("--mimics/--persona requires --target-ip")
 		}
-		types, err := expandMimics(*mimics)
-		if err != nil {
-			fail("--mimics: %v", err)
+		// The endpoint set comes from an explicit --mimics (power user) or, since the
+		// persona is deterministic from the token, from --persona resolved against the
+		// shared token — so the hub matches the foreign's persona without hand-listing.
+		var types []string
+		var err error
+		if *mimics != "" {
+			if types, err = expandMimics(*mimics); err != nil {
+				fail("--mimics: %v", err)
+			}
+		} else {
+			name := *personaFlag
+			if name == "auto" {
+				name = persona.Auto(*token)
+			} else if !persona.Known(name) {
+				fail("--persona must be auto|%s", strings.Join(persona.Names(), "|"))
+			}
+			if types, err = persona.Resolve(name, *token); err != nil {
+				fail("--persona: %v", err)
+			}
+			color.Green("[✓] Persona %q: dialing the foreign across %d endpoints.", name, len(types))
 		}
 		for label, p := range map[string]int{
 			"ssh-port": *sshPort, "tls-port": *tlsPort, "smtp-port": *smtpPort, "imap-port": *imapPort,
@@ -366,7 +384,7 @@ func cmdAddNode(args []string) {
 		}
 		endpoints = []config.Endpoint{{Target: *target, Mimic: "ssh"}}
 	default:
-		fail("provide --target-ip --mimics ... or --target HOST:PORT")
+		fail("provide --target-ip with --persona ... or --mimics ..., or --target HOST:PORT")
 	}
 
 	pMin, pMax, pBw, pJit := speedProfile(*profile)

--- a/cmd/hedioum/wizard.go
+++ b/cmd/hedioum/wizard.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/persona"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/sysutil"
 )
 
@@ -58,8 +59,34 @@ func setupForeignNode(cfg *config.AppConfig) {
 		Default: detectedIP,
 	}, &ip, survey.WithValidator(survey.Required))
 
-	// Which camouflages this node listens behind (checkbox; "all" = whole arsenal).
-	mimics := promptMimics()
+	// Choose a coherent server persona (SSH + 9 mimics) seeded from the token, or a
+	// custom mimic set. The token is generated now so it can seed the persona.
+	token := sysutil.GenerateSecureToken()
+	var personaChoice string
+	survey.AskOne(&survey.Select{
+		Message: "Server persona (shapes the whole on-wire footprint):",
+		Options: append([]string{"auto (recommended)"}, append(persona.Names(), "custom (choose mimics)")...),
+		Default: "auto (recommended)",
+		Help:    "auto = a coherent persona seeded from your token. cpanel/directadmin/devops force one. custom = pick individual mimics.",
+	}, &personaChoice)
+
+	var mimics []string
+	chosenPersona := ""
+	if strings.HasPrefix(personaChoice, "custom") {
+		mimics = promptMimics()
+	} else {
+		chosenPersona = strings.Fields(personaChoice)[0] // "auto"/"cpanel"/...
+		if chosenPersona == "auto" {
+			chosenPersona = persona.Auto(token)
+		}
+		var err error
+		if mimics, err = persona.Resolve(chosenPersona, token); err != nil {
+			color.Red("[x] persona %q: %v — falling back to a manual selection.", chosenPersona, err)
+			chosenPersona, mimics = "", promptMimics()
+		} else {
+			color.Green("[✓] Persona %q: %s", chosenPersona, strings.Join(mimics, ", "))
+		}
+	}
 
 	// SSH-specific prompts only matter when the SSH mimic is enabled.
 	listenPort := 22
@@ -103,7 +130,8 @@ func setupForeignNode(cfg *config.AppConfig) {
 	cfg.ForeignListenPort = listenPort
 	cfg.DecoyPort = decoyPort
 	cfg.Mimics = mimicList
-	cfg.AuthToken = sysutil.GenerateSecureToken()
+	cfg.Persona = chosenPersona
+	cfg.AuthToken = token
 
 	// IPv6 egress is opt-in (default IPv4-only to avoid leaking the v6 identity).
 	cfg.EgressIPMode = "ipv4"
@@ -143,14 +171,14 @@ func setupForeignNode(cfg *config.AppConfig) {
 		color.Yellow("  [!] Using a self-signed certificate. A domain is recommended when possible.")
 	}
 
-	// Camouflage persona shown to unauthorized probes / scanners.
-	persona := ""
+	// Web-decoy style shown to unauthorized probes on the plain web ports.
+	decoyStyle := ""
 	survey.AskOne(&survey.Select{
-		Message: "Decoy persona for unauthorized probes:",
+		Message: "Web-decoy style for unauthorized probes:",
 		Options: []string{"apache (Apache default page)", "directadmin (DirectAdmin hosting box)"},
 		Default: "apache (Apache default page)",
-	}, &persona)
-	if strings.HasPrefix(persona, "directadmin") {
+	}, &decoyStyle)
+	if strings.HasPrefix(decoyStyle, "directadmin") {
 		cfg.DecoyStyle = "directadmin"
 	} else {
 		cfg.DecoyStyle = "apache"

--- a/cmd/hedioum/wizard.go
+++ b/cmd/hedioum/wizard.go
@@ -270,10 +270,34 @@ func setupIranNode(cfg *config.AppConfig, isFirstTime bool) {
 	node.BandwidthLimitMbps = safeAtoi(answers.BandwidthLimit, 8)
 	node.BandwidthJitterMbps = safeAtoi(answers.BandwidthJitter, 2)
 
-	// Which mimics to reach this node over (checkbox; must match what the foreign
-	// node runs). Populating Endpoints is what enables the multi-mimic arsenal —
-	// without it the node falls back to a single synthesized SSH endpoint.
-	for _, ty := range promptMimics() {
+	// Which mimics to reach this node over — must match what the foreign runs. Since
+	// the persona is deterministic from the token, "auto" derives the exact set the
+	// foreign chose; or match a named persona, or pick manually.
+	var mimicTypes []string
+	hubPersonaChoice := ""
+	survey.AskOne(&survey.Select{
+		Message: "Match the foreign's mimic set:",
+		Options: append([]string{"auto (from token)"}, append(persona.Names(), "custom (choose mimics)")...),
+		Default: "auto (from token)",
+		Help:    "auto derives the foreign's persona from the shared token. Or force a named persona, or pick individual mimics.",
+	}, &hubPersonaChoice)
+	if strings.HasPrefix(hubPersonaChoice, "custom") {
+		mimicTypes = promptMimics()
+	} else {
+		name := strings.Fields(hubPersonaChoice)[0]
+		if name == "auto" {
+			name = persona.Auto(node.AuthToken)
+		}
+		if types, err := persona.Resolve(name, node.AuthToken); err == nil {
+			mimicTypes = types
+			color.Green("[✓] Persona %q → %d endpoints", name, len(types))
+		} else {
+			mimicTypes = promptMimics()
+		}
+	}
+	// Populating Endpoints is what enables the multi-mimic arsenal — without it the
+	// node falls back to a single synthesized SSH endpoint.
+	for _, ty := range mimicTypes {
 		node.Endpoints = append(node.Endpoints, config.Endpoint{
 			Target: net.JoinHostPort(node.TargetIP, strconv.Itoa(mimicPort(ty, node.TargetPort))),
 			Mimic:  ty,

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,11 @@ type AppConfig struct {
 	// DirectAdmin hosting box — "webserver is functioning normally" on the web ports
 	// and the DirectAdmin panel on :2222).
 	DecoyStyle string `json:"decoy_style,omitempty"`
+	// Persona is the coherent server identity the foreign wears — "cpanel",
+	// "directadmin", or "devops" — which determines the mimic set (SSH + 9). Empty
+	// means a custom mimic set was chosen explicitly (via --mimics) rather than a
+	// persona. Recorded so edit/status can show it and re-resolve it.
+	Persona string `json:"persona,omitempty"`
 	// Mimics lists the camouflage listeners the foreign runs (SSH, TLS, ...). If
 	// empty, a single SSH listener is synthesized from ForeignListenPort/DecoyPort.
 	Mimics []MimicListener `json:"mimics,omitempty"`

--- a/internal/persona/persona.go
+++ b/internal/persona/persona.go
@@ -1,0 +1,145 @@
+// Package persona groups the mimic library into coherent server identities. Instead
+// of a random grab-bag of camouflage listeners, each install wears one persona — the
+// SSH backbone plus a fixed set of non-SSH mimics that together look like one real,
+// ordinary server (a cPanel host, a DirectAdmin host, or a DevOps/app host). This
+// keeps the on-wire footprint internally consistent (a host never runs both cPanel
+// and DirectAdmin, for example), while a per-install seed still makes two installs of
+// the same persona differ in their optional ports.
+package persona
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sort"
+)
+
+// backbone is the long-lived mimic every persona is built on. Every server has SSH,
+// so it is universally consistent; it is always added first.
+const backbone = "ssh"
+
+// A Persona is a coherent identity. Core mimics define it and are always present;
+// the rest are filled deterministically from Pool (in seeded order) up to Size.
+type Persona struct {
+	Name string
+	Core []string // always included (besides ssh); defines the identity
+	Pool []string // seeded fill, drawn until Size is reached
+	Size int      // number of non-ssh mimics (ssh is always added on top)
+}
+
+// Registry holds the coherent personas. Every persona's Core includes "tls" (:443),
+// guaranteeing an always-reachable bootstrap path. "cpanel" and "directadmin" are
+// mutually exclusive by construction (the panel-family coherence rule).
+var Registry = map[string]Persona{
+	"cpanel": {
+		Name: "cpanel",
+		Core: []string{"tls", "cpanel", "whm", "webmail"},
+		Pool: []string{"https-alt", "smtp", "smtps", "imaps", "imap", "postgres", "mysql", "docker"},
+		Size: 9,
+	},
+	"directadmin": {
+		Name: "directadmin",
+		Core: []string{"tls", "directadmin"},
+		Pool: []string{"https-alt", "smtp", "smtps", "imaps", "imap", "postgres", "mysql", "docker", "grafana"},
+		Size: 9,
+	},
+	"devops": {
+		Name: "devops",
+		Core: []string{"tls", "https-alt", "docker", "grafana", "prometheus"},
+		Pool: []string{"postgres", "mysql", "smtp", "smtps", "imap", "imaps"},
+		Size: 9,
+	},
+}
+
+// order is the stable persona order for listing and deterministic Auto selection.
+var order = []string{"cpanel", "directadmin", "devops"}
+
+// Names lists the persona names in a stable order.
+func Names() []string {
+	out := make([]string, len(order))
+	copy(out, order)
+	return out
+}
+
+// Known reports whether name is a defined persona.
+func Known(name string) bool {
+	_, ok := Registry[name]
+	return ok
+}
+
+// Auto deterministically selects a persona from the seed (the node's secret token),
+// so a server always wears the same persona and the population spreads across all three.
+func Auto(seed string) string {
+	h := sha256.Sum256([]byte("hedioum-persona\x00" + seed))
+	return order[int(h[0])%len(order)]
+}
+
+// Resolve returns the ordered mimic-type set for a persona: the SSH backbone first,
+// then Core (in definition order), then a deterministic seeded fill from Pool up to
+// Size. The result always has Size+1 entries (ssh + Size) and is coherent.
+func Resolve(name, seed string) ([]string, error) {
+	p, ok := Registry[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown persona %q (want one of %v)", name, order)
+	}
+	set := []string{backbone}
+	seen := map[string]bool{backbone: true}
+	for _, m := range p.Core {
+		if !seen[m] {
+			set = append(set, m)
+			seen[m] = true
+		}
+	}
+	for _, m := range seededOrder(p.Pool, seed) {
+		if len(set)-1 >= p.Size {
+			break
+		}
+		if !seen[m] {
+			set = append(set, m)
+			seen[m] = true
+		}
+	}
+	if len(set)-1 != p.Size {
+		return nil, fmt.Errorf("persona %q: pool too small to reach size %d", name, p.Size)
+	}
+	return set, nil
+}
+
+// CheckCoherence rejects an incoherent mimic set. A real server never runs both
+// cPanel (cpanel/whm/webmail) and DirectAdmin, so they must not share one host.
+func CheckCoherence(mimics []string) error {
+	has := make(map[string]bool, len(mimics))
+	for _, m := range mimics {
+		has[m] = true
+	}
+	if (has["cpanel"] || has["whm"] || has["webmail"]) && has["directadmin"] {
+		return fmt.Errorf("incoherent mimic set: cPanel family and DirectAdmin must not run on the same host")
+	}
+	return nil
+}
+
+// seededOrder returns items in a deterministic per-seed order: each item gets a
+// hash-derived key from (seed, item), and the items are sorted by that key. Same seed
+// → same order; different seeds → different fills, so same-persona installs vary.
+func seededOrder(items []string, seed string) []string {
+	type kv struct {
+		k uint64
+		v string
+	}
+	arr := make([]kv, len(items))
+	for i, it := range items {
+		h := sha256.Sum256([]byte("hedioum-fill\x00" + seed + "\x00" + it))
+		arr[i] = kv{binary.BigEndian.Uint64(h[:8]), it}
+	}
+	sort.Slice(arr, func(i, j int) bool {
+		if arr[i].k != arr[j].k {
+			return arr[i].k < arr[j].k
+		}
+		return arr[i].v < arr[j].v
+	})
+	out := make([]string, len(items))
+	for i, e := range arr {
+		out[i] = e.v
+	}
+	return out
+}

--- a/internal/persona/persona_test.go
+++ b/internal/persona/persona_test.go
@@ -1,0 +1,97 @@
+package persona
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestResolveShapeAndCoherence: every persona resolves to ssh + exactly 9, includes
+// its core (with tls), is coherent, and has no duplicates.
+func TestResolveShapeAndCoherence(t *testing.T) {
+	for _, name := range Names() {
+		set, err := Resolve(name, "seed-"+name)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(set) != 10 {
+			t.Fatalf("%s: got %d mimics, want 10 (ssh + 9): %v", name, len(set), set)
+		}
+		if set[0] != "ssh" {
+			t.Fatalf("%s: backbone must be first, got %q", name, set[0])
+		}
+		seen := map[string]bool{}
+		for _, m := range set {
+			if seen[m] {
+				t.Fatalf("%s: duplicate %q in %v", name, m, set)
+			}
+			seen[m] = true
+		}
+		if !seen["tls"] {
+			t.Fatalf("%s: every persona must include tls (:443) for bootstrap: %v", name, set)
+		}
+		for _, c := range Registry[name].Core {
+			if !seen[c] {
+				t.Fatalf("%s: core mimic %q missing: %v", name, c, set)
+			}
+		}
+		if err := CheckCoherence(set); err != nil {
+			t.Fatalf("%s: resolved set is incoherent: %v", name, err)
+		}
+	}
+}
+
+// TestDeterministic: same (persona, seed) → identical set; the order is stable.
+func TestDeterministic(t *testing.T) {
+	a, _ := Resolve("cpanel", "token-A")
+	b, _ := Resolve("cpanel", "token-A")
+	if strings.Join(a, ",") != strings.Join(b, ",") {
+		t.Fatalf("not deterministic:\n%v\n%v", a, b)
+	}
+}
+
+// TestSeedVariation: two different seeds of the same persona differ in their fill
+// (the pool is larger than the slack), so same-persona installs are not identical.
+func TestSeedVariation(t *testing.T) {
+	seen := map[string]int{}
+	for _, s := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		set, _ := Resolve("cpanel", s)
+		seen[strings.Join(set, ",")]++
+	}
+	if len(seen) < 2 {
+		t.Fatalf("expected fill variation across seeds, got only %d distinct sets", len(seen))
+	}
+}
+
+// TestAutoSpreads: Auto distributes across all three personas over many seeds and is
+// deterministic per seed.
+func TestAutoSpreads(t *testing.T) {
+	if Auto("x") != Auto("x") {
+		t.Fatal("Auto must be deterministic per seed")
+	}
+	got := map[string]bool{}
+	for i := 0; i < 200; i++ {
+		got[Auto(string(rune('a'+i%26))+string(rune('0'+i/26)))] = true
+	}
+	for _, name := range Names() {
+		if !got[name] {
+			t.Fatalf("Auto never selected persona %q over 200 seeds", name)
+		}
+	}
+}
+
+// TestCoherenceValidator: the validator flags cPanel-family + DirectAdmin together.
+func TestCoherenceValidator(t *testing.T) {
+	if err := CheckCoherence([]string{"ssh", "tls", "cpanel", "directadmin"}); err == nil {
+		t.Fatal("cpanel + directadmin should be rejected as incoherent")
+	}
+	if err := CheckCoherence([]string{"ssh", "tls", "whm", "postgres"}); err != nil {
+		t.Fatalf("coherent cPanel set wrongly rejected: %v", err)
+	}
+}
+
+// TestUnknownPersona: Resolve errors on an unknown name.
+func TestUnknownPersona(t *testing.T) {
+	if _, err := Resolve("nope", "s"); err == nil {
+		t.Fatal("unknown persona should error")
+	}
+}


### PR DESCRIPTION
## Summary

Groups the 16-mimic library into three **coherent server personas** so each install wears one consistent on-wire footprint instead of a random grab-bag of listeners. A per-install seed still makes two installs of the same persona differ in their optional ports.

- **New `internal/persona` package** — `cpanel`, `directadmin`, `devops`, each a Core set (always including `tls`:443 for an always-reachable bootstrap) plus a deterministic seeded fill from a Pool up to **SSH + 9**. Same token → same persona/ports; different tokens spread across personas and vary the fill. `CheckCoherence` enforces the hard rule: **cPanel family and DirectAdmin never share a host**.
- **`AppConfig.Persona`** records the chosen identity.
- **setup-foreign** — `--persona auto|cpanel|directadmin|devops` (default `auto`, seeded from the token); an explicit `--mimics` still overrides (and is coherence-checked with a warning).
- **add-node / setup-iran (hub)** — `--persona` derives the *same* endpoint set from the shared token, so the hub matches the foreign without hand-listing mimics.
- **wizard** — persona pickers on both the foreign and hub paths.
- **edit-foreign** — `--persona` re-resolves the set (closing/opening listeners cleanly); the current persona is otherwise preserved.
- **dashboard** — shows the active persona.

## Live validation (Iran hub ↔ foreign)

- Each persona resolves to a coherent SSH+9 set (cpanel has no directadmin and vice-versa); `auto` is deterministic (same token → identical set); `--mimics all` overrides to 16 with no persona; the coherence warning fires for `cpanel,directadmin`.
- `edit-foreign --persona devops` cleanly swaps the listener set (old persona's ports closed, no orphans); the persona field persists.
- **Symmetry:** foreign `--persona auto` and hub `--persona auto` with the same token independently resolve to the identical set; all endpoints probe OK; the tunnel carries traffic (censored sites reachable) end-to-end.

## Notes

Full unit coverage (persona shape/coherence/determinism/seed-variation/Auto-spread + a CLI cross-check that every persona maps to real, port-mapped mimic types). Version stays at v0.8.0 — per plan, M2–M4 land under separate PRs and the tag bumps to v0.9.0 at the end of M4.