### PR TITLE
Self-contained v2 pairing token — paste-only hub onboarding (M3)

### DIFF
--- a/cmd/hedioum/setup_cmd.go
+++ b/cmd/hedioum/setup_cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/pairing"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/persona"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/sysutil"
 )
@@ -99,6 +100,7 @@ func cmdSetupForeign(args []string) {
 	moveSSH := fs.Bool("move-ssh", false, "relocate OpenSSH to --decoy-port")
 	httpDecoyPort := fs.Int("http-decoy-port", 80, "plaintext web decoy port (0 to disable)")
 	token := fs.String("token", "", "auth token (generated if empty)")
+	publicIP := fs.String("public-ip", "", "public IP to embed in the pairing token (auto-detected if empty)")
 	_ = fs.Parse(args)
 
 	switch *decoyStyle {
@@ -269,6 +271,30 @@ func cmdSetupForeign(args []string) {
 	} else {
 		color.Green("[✓] Domain %s: a real Let's Encrypt cert will be obtained once DNS points here.", *domain)
 	}
+	// Emit a self-contained v2 pairing token (exit IP + ports + persona + key) so the
+	// hub onboards by pasting one string — no --target-ip/--mimics to match by hand.
+	exitIP := *publicIP
+	if exitIP == "" {
+		if ip, err := sysutil.GetPublicIPv4(); err == nil {
+			exitIP = ip
+		}
+	}
+	if exitIP != "" {
+		eps := make(map[string]int, len(mimicList))
+		for _, m := range mimicList {
+			eps[m.Type] = m.Port
+		}
+		sni := *tlsServerName
+		if sni == "" {
+			sni = *domain
+		}
+		pt := pairing.Encode(pairing.Token{ExitIP: exitIP, AuthKey: tok, Persona: chosenPersona, SNI: sni, Endpoints: eps})
+		color.HiGreen("\n[✓] Pairing token (paste into the hub — carries IP, ports, persona & key):")
+		fmt.Println(pt)
+	} else {
+		color.Yellow("[!] Public IP not detected: on the hub use the raw token below with --target-ip,")
+		color.Yellow("    or re-run with --public-ip <ip> to emit a paste-only pairing token.")
+	}
 	fmt.Printf("Auth Token: %s\n", tok)
 	// Apply immediately: without a restart the daemon keeps its old config (old
 	// mimics AND old token), which silently breaks the link after re-provisioning.
@@ -318,12 +344,46 @@ func cmdAddNode(args []string) {
 	if err := validPort(*socksPort); err != nil {
 		fail("--socks-port: %v", err)
 	}
-	if err := validToken(*token); err != nil {
+	// A v2 pairing token is self-contained (IP + ports + persona + key); a v1 token is
+	// a bare hex secret used with --target-ip and --persona/--mimics.
+	pairTok, isV2, perr := pairing.Decode(*token)
+	if perr != nil {
+		fail("--token: %v", perr)
+	}
+	authKey := *token
+	if isV2 {
+		authKey = pairTok.AuthKey
+	}
+	if err := validToken(authKey); err != nil {
 		fail("--token: %v", err)
 	}
 
 	var endpoints []config.Endpoint
 	switch {
+	case isV2:
+		if *targetIP != "" || *mimics != "" || *personaFlag != "" {
+			color.Yellow("[!] v2 pairing token is self-contained; ignoring --target-ip/--mimics/--persona.")
+		}
+		for _, ty := range mimicTypesAll {
+			port, ok := pairTok.Endpoints[ty]
+			if !ok {
+				continue
+			}
+			sni := ""
+			if ty != "ssh" {
+				sni = pairTok.SNI
+			}
+			endpoints = append(endpoints, config.Endpoint{
+				Target:     net.JoinHostPort(pairTok.ExitIP, strconv.Itoa(port)),
+				Mimic:      ty,
+				ServerName: sni,
+			})
+		}
+		label := pairTok.Persona
+		if label == "" {
+			label = "custom"
+		}
+		color.Green("[✓] Pairing token: %s persona, %d endpoints @ %s.", label, len(endpoints), pairTok.ExitIP)
 	case *mimics != "" || *personaFlag != "":
 		if *targetIP == "" {
 			fail("--mimics/--persona requires --target-ip")
@@ -340,11 +400,11 @@ func cmdAddNode(args []string) {
 		} else {
 			name := *personaFlag
 			if name == "auto" {
-				name = persona.Auto(*token)
+				name = persona.Auto(authKey)
 			} else if !persona.Known(name) {
 				fail("--persona must be auto|%s", strings.Join(persona.Names(), "|"))
 			}
-			if types, err = persona.Resolve(name, *token); err != nil {
+			if types, err = persona.Resolve(name, authKey); err != nil {
 				fail("--persona: %v", err)
 			}
 			color.Green("[✓] Persona %q: dialing the foreign across %d endpoints.", name, len(types))
@@ -384,7 +444,7 @@ func cmdAddNode(args []string) {
 		}
 		endpoints = []config.Endpoint{{Target: *target, Mimic: "ssh"}}
 	default:
-		fail("provide --target-ip with --persona ... or --mimics ..., or --target HOST:PORT")
+		fail("provide a v2 pairing token, or --target-ip with --persona/--mimics, or --target HOST:PORT")
 	}
 
 	pMin, pMax, pBw, pJit := speedProfile(*profile)
@@ -415,7 +475,7 @@ func cmdAddNode(args []string) {
 	cfg.UpdateForeignNode(config.ForeignNode{
 		Alias:               *alias,
 		LocalSocksPort:      *socksPort,
-		AuthToken:           *token,
+		AuthToken:           authKey,
 		Endpoints:           endpoints,
 		MinConnections:      pMin,
 		MaxConnections:      pMax,

--- a/cmd/hedioum/setup_cmd.go
+++ b/cmd/hedioum/setup_cmd.go
@@ -289,13 +289,16 @@ func cmdSetupForeign(args []string) {
 			sni = *domain
 		}
 		pt := pairing.Encode(pairing.Token{ExitIP: exitIP, AuthKey: tok, Persona: chosenPersona, SNI: sni, Endpoints: eps})
-		color.HiGreen("\n[✓] Pairing token (paste into the hub — carries IP, ports, persona & key):")
+		color.HiGreen("\n━━━ Hub onboarding ━━━")
+		color.HiGreen("Paste THIS pairing token into the hub — it already carries the exit IP, every")
+		color.HiGreen("port, and the persona, so the hub needs no --target-ip/--persona/--mimics:")
 		fmt.Println(pt)
+		color.HiBlack("(Raw auth key, for advanced/legacy setups only: %s)", tok)
 	} else {
 		color.Yellow("[!] Public IP not detected: on the hub use the raw token below with --target-ip,")
 		color.Yellow("    or re-run with --public-ip <ip> to emit a paste-only pairing token.")
+		fmt.Printf("Auth Token: %s\n", tok)
 	}
-	fmt.Printf("Auth Token: %s\n", tok)
 	// Apply immediately: without a restart the daemon keeps its old config (old
 	// mimics AND old token), which silently breaks the link after re-provisioning.
 	restartDaemon()

--- a/cmd/hedioum/wizard.go
+++ b/cmd/hedioum/wizard.go
@@ -238,7 +238,7 @@ func setupIranNode(cfg *config.AppConfig, isFirstTime bool) {
 		},
 		{
 			Name:     "authtoken",
-			Prompt:   &survey.Input{Message: "Authentication Token (from egress server):"},
+			Prompt:   &survey.Input{Message: "Pairing token from the egress server (carries IP/ports/persona; a legacy auth token also works):"},
 			Validate: survey.Required,
 		},
 	}
@@ -304,10 +304,10 @@ func setupIranNode(cfg *config.AppConfig, isFirstTime bool) {
 	if !fromToken {
 		hubPersonaChoice := ""
 		survey.AskOne(&survey.Select{
-			Message: "Match the foreign's mimic set:",
+			Message: "Match the foreign's mimic set (tip: paste the v2 pairing token instead to skip this):",
 			Options: append([]string{"auto (from token)"}, append(persona.Names(), "custom (choose mimics)")...),
 			Default: "auto (from token)",
-			Help:    "auto derives the foreign's persona from the shared token. Or force a named persona, or pick individual mimics.",
+			Help:    "auto matches an auto-configured foreign (same token → same persona). If the foreign FORCED a persona, choose that name here, or use the pairing token.",
 		}, &hubPersonaChoice)
 		if strings.HasPrefix(hubPersonaChoice, "custom") {
 			mimicTypes = promptMimics()

--- a/cmd/hedioum/wizard.go
+++ b/cmd/hedioum/wizard.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
+	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/pairing"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/persona"
 	"github.com/hedioum/Hedioum-Pool-Tunnel/internal/sysutil"
 )
@@ -262,6 +263,31 @@ func setupIranNode(cfg *config.AppConfig, isFirstTime bool) {
 	node.TargetIP = answers.TargetIP
 	node.AuthToken = answers.AuthToken
 
+	// A v2 pairing token is self-contained: it overrides the IP and endpoint set, so
+	// the operator only has to paste it (the IP prompt above is ignored).
+	fromToken := false
+	if pt, isV2, err := pairing.Decode(strings.TrimSpace(answers.AuthToken)); err == nil && isV2 {
+		fromToken = true
+		node.TargetIP = pt.ExitIP
+		node.AuthToken = pt.AuthKey
+		for _, ty := range mimicTypesAll {
+			if port, ok := pt.Endpoints[ty]; ok {
+				sni := ""
+				if ty != "ssh" {
+					sni = pt.SNI
+				}
+				node.Endpoints = append(node.Endpoints, config.Endpoint{
+					Target: net.JoinHostPort(pt.ExitIP, strconv.Itoa(port)), Mimic: ty, ServerName: sni,
+				})
+			}
+		}
+		label := pt.Persona
+		if label == "" {
+			label = "custom"
+		}
+		color.Green("[✓] Pairing token: %s persona, %d endpoints @ %s", label, len(node.Endpoints), pt.ExitIP)
+	}
+
 	// Safely parse all integer inputs, falling back to defaults if empty or invalid (0)
 	node.TargetPort = safeAtoi(answers.TargetPort, 22)
 	node.LocalSocksPort = safeAtoi(answers.LocalSocksPort, safeAtoi(suggestedSocksPort, 40001))
@@ -270,29 +296,32 @@ func setupIranNode(cfg *config.AppConfig, isFirstTime bool) {
 	node.BandwidthLimitMbps = safeAtoi(answers.BandwidthLimit, 8)
 	node.BandwidthJitterMbps = safeAtoi(answers.BandwidthJitter, 2)
 
-	// Which mimics to reach this node over — must match what the foreign runs. Since
-	// the persona is deterministic from the token, "auto" derives the exact set the
+	// Which mimics to reach this node over — must match what the foreign runs. A v2
+	// pairing token already populated the endpoints above; otherwise, since the
+	// persona is deterministic from the token, "auto" derives the exact set the
 	// foreign chose; or match a named persona, or pick manually.
 	var mimicTypes []string
-	hubPersonaChoice := ""
-	survey.AskOne(&survey.Select{
-		Message: "Match the foreign's mimic set:",
-		Options: append([]string{"auto (from token)"}, append(persona.Names(), "custom (choose mimics)")...),
-		Default: "auto (from token)",
-		Help:    "auto derives the foreign's persona from the shared token. Or force a named persona, or pick individual mimics.",
-	}, &hubPersonaChoice)
-	if strings.HasPrefix(hubPersonaChoice, "custom") {
-		mimicTypes = promptMimics()
-	} else {
-		name := strings.Fields(hubPersonaChoice)[0]
-		if name == "auto" {
-			name = persona.Auto(node.AuthToken)
-		}
-		if types, err := persona.Resolve(name, node.AuthToken); err == nil {
-			mimicTypes = types
-			color.Green("[✓] Persona %q → %d endpoints", name, len(types))
-		} else {
+	if !fromToken {
+		hubPersonaChoice := ""
+		survey.AskOne(&survey.Select{
+			Message: "Match the foreign's mimic set:",
+			Options: append([]string{"auto (from token)"}, append(persona.Names(), "custom (choose mimics)")...),
+			Default: "auto (from token)",
+			Help:    "auto derives the foreign's persona from the shared token. Or force a named persona, or pick individual mimics.",
+		}, &hubPersonaChoice)
+		if strings.HasPrefix(hubPersonaChoice, "custom") {
 			mimicTypes = promptMimics()
+		} else {
+			name := strings.Fields(hubPersonaChoice)[0]
+			if name == "auto" {
+				name = persona.Auto(node.AuthToken)
+			}
+			if types, err := persona.Resolve(name, node.AuthToken); err == nil {
+				mimicTypes = types
+				color.Green("[✓] Persona %q → %d endpoints", name, len(types))
+			} else {
+				mimicTypes = promptMimics()
+			}
 		}
 	}
 	// Populating Endpoints is what enables the multi-mimic arsenal — without it the

--- a/internal/pairing/token.go
+++ b/internal/pairing/token.go
@@ -1,0 +1,83 @@
+// Package pairing defines the self-contained pairing token a foreign node prints and
+// an operator pastes into the hub. Where the v1 token was a bare 32-hex auth secret
+// that had to be paired with a hand-typed --target-ip and a matching --mimics/--persona,
+// the v2 token carries everything the hub needs — the exit IP, the auth key (which is
+// also the persona seed), the chosen persona, the TLS SNI, and the actual mimic->port
+// map — so hub onboarding is paste-only. The v1 hex token is still accepted.
+package pairing
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// Version is the current pairing-token version.
+const Version = 2
+
+// Token is a v2 pairing token payload.
+type Token struct {
+	Version   int            `json:"v"`
+	ExitIP    string         `json:"ip"`
+	AuthKey   string         `json:"auth"`              // the 32-hex auth secret (also the persona seed)
+	Persona   string         `json:"persona,omitempty"` // informational: the persona the foreign wears
+	SNI       string         `json:"sni,omitempty"`     // TLS SNI/CN the hub should present ("" = self-signed)
+	Endpoints map[string]int `json:"eps"`               // mimic type -> public port the foreign listens on
+}
+
+var legacyHex = regexp.MustCompile(`^[A-Fa-f0-9]{32}$`)
+
+// IsLegacyHex reports whether s is a bare v1 auth token (32 hex chars).
+func IsLegacyHex(s string) bool { return legacyHex.MatchString(s) }
+
+// Encode renders a token as a compact base64url pairing string.
+func Encode(t Token) string {
+	t.Version = Version
+	b, _ := json.Marshal(t)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// Decode parses a pairing string. It returns (token, true, nil) for a valid v2 token,
+// (nil, false, nil) for a bare v1 hex token (the caller falls back to the flag-driven
+// flow), or (nil, false, err) for anything malformed.
+func Decode(s string) (*Token, bool, error) {
+	if IsLegacyHex(s) {
+		return nil, false, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		if raw, err = base64.StdEncoding.DecodeString(s); err != nil {
+			return nil, false, fmt.Errorf("token is neither a v1 hex token nor a valid v2 pairing token")
+		}
+	}
+	var t Token
+	if err := json.Unmarshal(raw, &t); err != nil {
+		return nil, false, fmt.Errorf("invalid v2 pairing token: %w", err)
+	}
+	if t.Version != Version {
+		return nil, false, fmt.Errorf("unsupported pairing token version %d (want %d)", t.Version, Version)
+	}
+	if err := t.validate(); err != nil {
+		return nil, false, err
+	}
+	return &t, true, nil
+}
+
+func (t Token) validate() error {
+	if !legacyHex.MatchString(t.AuthKey) {
+		return fmt.Errorf("pairing token has an invalid auth key")
+	}
+	if t.ExitIP == "" {
+		return fmt.Errorf("pairing token has no exit IP")
+	}
+	if len(t.Endpoints) == 0 {
+		return fmt.Errorf("pairing token has no endpoints")
+	}
+	for ty, port := range t.Endpoints {
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("pairing token endpoint %q has invalid port %d", ty, port)
+		}
+	}
+	return nil
+}

--- a/internal/pairing/token_test.go
+++ b/internal/pairing/token_test.go
@@ -1,0 +1,63 @@
+package pairing
+
+import "testing"
+
+// TestRoundTrip: a token encodes and decodes back to the same fields.
+func TestRoundTrip(t *testing.T) {
+	in := Token{
+		ExitIP:  "95.179.148.154",
+		AuthKey: "aabbccddeeff00112233445566778899",
+		Persona: "cpanel",
+		SNI:     "vpn.example.com",
+		Endpoints: map[string]int{
+			"ssh": 2200, "tls": 443, "cpanel": 2083, "mysql": 3306,
+		},
+	}
+	s := Encode(in)
+	got, isV2, err := Decode(s)
+	if err != nil || !isV2 {
+		t.Fatalf("decode: isV2=%v err=%v", isV2, err)
+	}
+	if got.Version != Version || got.ExitIP != in.ExitIP || got.AuthKey != in.AuthKey ||
+		got.Persona != in.Persona || got.SNI != in.SNI || len(got.Endpoints) != len(in.Endpoints) {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	for k, v := range in.Endpoints {
+		if got.Endpoints[k] != v {
+			t.Fatalf("endpoint %s: got %d want %d", k, got.Endpoints[k], v)
+		}
+	}
+}
+
+// TestLegacyHex: a bare v1 hex token is recognized and not treated as v2.
+func TestLegacyHex(t *testing.T) {
+	hex := "0189e772bfe63d815f026b8f76d292ea"
+	if !IsLegacyHex(hex) {
+		t.Fatal("should be legacy hex")
+	}
+	tok, isV2, err := Decode(hex)
+	if err != nil || isV2 || tok != nil {
+		t.Fatalf("legacy hex should decode to (nil,false,nil): %v %v %v", tok, isV2, err)
+	}
+}
+
+// TestRejectGarbage: an unparseable string errors.
+func TestRejectGarbage(t *testing.T) {
+	if _, _, err := Decode("!!!not-a-token!!!"); err == nil {
+		t.Fatal("garbage should error")
+	}
+}
+
+// TestValidation: decode rejects a token with a bad auth key, no IP, or no endpoints.
+func TestValidation(t *testing.T) {
+	for _, bad := range []Token{
+		{ExitIP: "1.2.3.4", AuthKey: "short", Endpoints: map[string]int{"tls": 443}},
+		{ExitIP: "", AuthKey: "aabbccddeeff00112233445566778899", Endpoints: map[string]int{"tls": 443}},
+		{ExitIP: "1.2.3.4", AuthKey: "aabbccddeeff00112233445566778899", Endpoints: map[string]int{}},
+		{ExitIP: "1.2.3.4", AuthKey: "aabbccddeeff00112233445566778899", Endpoints: map[string]int{"tls": 0}},
+	} {
+		if _, _, err := Decode(Encode(bad)); err == nil {
+			t.Fatalf("should reject: %+v", bad)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Onboarding a hub used to mean pairing a bare hex token with a hand-typed `--target-ip` and a **matching** `--persona`/`--mimics` — and since the foreign picks its persona automatically, the operator had no way to know which persona to match. The **v2 pairing token** fixes this: it carries everything, so the hub *reads* the persona and ports instead of guessing them.

- **New `internal/pairing` package** — a base64url token carrying `{exit IP, auth key (also the persona seed), persona, TLS SNI, the actual mimic→port map}`, with `Encode`/`Decode` and v1-hex detection so the old flow still works.
- **setup-foreign** emits the pairing token (auto-detecting the public IP, or `--public-ip`), framed as *the* thing to paste into the hub; the raw auth key is demoted to an advanced/legacy note.
- **add-node / setup-iran** — a v2 token is self-contained: it sets the target IP, all endpoints (including a non-default SSH port), the SNI and the auth key; `--target-ip`/`--mimics`/`--persona` are ignored with a notice. A v1 hex token keeps the flag-driven flow.
- **wizard** hub path auto-configures from a pasted v2 token (skips the mimic picker); prompts and help steer operators to the pairing token.

## How this answers "which persona does the hub pick?"

- **v2 token (recommended):** the persona + exact ports are *in the token* — the hub shows e.g. "directadmin persona, 10 endpoints" and needs no choice.
- **v1 hex + `--persona auto`:** `auto` is the same deterministic `Auto(token)` the foreign used, so the shared token lands both ends on the same persona.
- **Only edge case:** if the foreign *forces* a persona, a v1 hex token can't convey it — use the v2 token (which carries it), or pass the same `--persona name`.

## Live validation (Iran hub ↔ foreign)

- Foreign `--persona auto` emitted a token; the hub onboarded with **only** that token and reconstructed all 10 persona endpoints (incl. the non-default `ssh:2200` carried in the token); probe 10/10 OK; tunnel carries traffic (exit = foreign, censored site 200).
- The v1 hex token + `--persona auto` path still resolves the identical set (backward compat).

## Scope

This is the token-v2 half of M3. The optional live post-auth persona advertisement (auto-healing the hub after a *foreign-side* persona edit without re-pairing) is deferred — re-pairing is now a one-paste operation, and M4's multi-port connect-race already absorbs a partially-stale endpoint set. Version stays at v0.8.0 (tag bumps to v0.9.0 at the end of M4).