### PR TITLE
Multi-port connect-race + reachability memory (M4)

### DIFF
--- a/internal/ingress/dial.go
+++ b/internal/ingress/dial.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	mrand "math/rand/v2"
 	"net"
+	"sort"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/yamux"
@@ -71,12 +73,45 @@ func ProbeEndpoint(ep config.Endpoint, token string) (time.Duration, error) {
 }
 
 // endpointDialer spreads new physical pipes across a node's endpoints with random
-// per-node weights, so each server instance runs a different, shifting mix of
-// mimics (Chaos Mesh v2) — there is no fixed "10 SSH + 0 others" signature for DPI.
+// per-node weights (Chaos Mesh v2 — no fixed "10 SSH + 0 others" signature), and
+// tracks per-endpoint reachability so a censored entry port (e.g. an ISP that drops
+// outbound :22) is detected, skipped, and periodically retried. Each dial races across
+// candidate ports, so the tunnel still comes up when some ports are blocked.
 type endpointDialer struct {
 	node    config.ForeignNode
 	cfg     *yamux.Config
 	weights []float64
+
+	mu     sync.Mutex
+	health map[string]*epHealth // keyed by endpoint.Target
+}
+
+type epHealth struct {
+	fails         int
+	cooldownUntil time.Time
+}
+
+const (
+	dialMaxAttempts = 4                // candidate ports tried per dial (bounds a down-node stall)
+	epFailThreshold = 2                // consecutive fails before an endpoint is cooled down
+	epCooldownBase  = 60 * time.Second // first cooldown for a blocked endpoint (doubles per extra fail)
+	epCooldownMax   = 10 * time.Minute
+)
+
+// dialPriority orders fallback attempts by how likely a port is to be reachable from
+// a censored network: 443/8443 first, ssh last (it is the most commonly blocked).
+var dialPriority = map[string]int{
+	"tls": 0, "https-alt": 1,
+	"smtps": 2, "imaps": 2, "directadmin": 2, "cpanel": 2, "whm": 2, "webmail": 2,
+	"grafana": 2, "prometheus": 2, "docker": 2,
+	"smtp": 3, "imap": 3, "postgres": 4, "mysql": 4, "ssh": 5,
+}
+
+func dialRank(m string) int {
+	if r, ok := dialPriority[m]; ok {
+		return r
+	}
+	return 3
 }
 
 func newEndpointDialer(node config.ForeignNode) *endpointDialer {
@@ -84,38 +119,126 @@ func newEndpointDialer(node config.ForeignNode) *endpointDialer {
 	for i := range w {
 		w[i] = 0.3 + mrand.Float64() // per-node random bias
 	}
-	return &endpointDialer{node: node, cfg: hubYamuxConfig(), weights: w}
+	return &endpointDialer{node: node, cfg: hubYamuxConfig(), weights: w, health: map[string]*epHealth{}}
 }
 
-// pick chooses an endpoint by weighted random (drift emerges as the pool scales
-// pipes up and down over time).
-func (d *endpointDialer) pick() config.Endpoint {
-	if len(d.node.Endpoints) == 1 {
-		return d.node.Endpoints[0]
+// attemptOrder returns the endpoints to try for one dial, best-first: a weighted-
+// random primary pick among currently-reachable endpoints (for mimic diversity), then
+// the remaining reachable endpoints in innocuous-port-first order, then any
+// cooling-down endpoints as a last resort. Capped at dialMaxAttempts.
+func (d *endpointDialer) attemptOrder() []config.Endpoint {
+	eps := d.node.Endpoints
+	if len(eps) <= 1 {
+		return eps
 	}
-	total := 0.0
-	for _, w := range d.weights {
-		total += w
-	}
-	r := mrand.Float64() * total
-	for i, w := range d.weights {
-		if r -= w; r <= 0 {
-			return d.node.Endpoints[i]
+	now := time.Now()
+	d.mu.Lock()
+	var reachable, cooling []int
+	for i, ep := range eps {
+		if h := d.health[ep.Target]; h != nil && h.cooldownUntil.After(now) {
+			cooling = append(cooling, i)
+		} else {
+			reachable = append(reachable, i)
 		}
 	}
-	return d.node.Endpoints[len(d.node.Endpoints)-1]
+	d.mu.Unlock()
+
+	pool := reachable
+	if len(pool) == 0 { // everything cooled down — try anyway, the block may have lifted
+		pool, cooling = cooling, nil
+	}
+
+	primary := d.weightedPick(pool)
+	seen := map[int]bool{primary: true}
+	order := []int{primary}
+
+	rest := append([]int(nil), pool...)
+	sort.SliceStable(rest, func(a, b int) bool {
+		return dialRank(eps[rest[a]].Mimic) < dialRank(eps[rest[b]].Mimic)
+	})
+	for _, i := range rest {
+		if !seen[i] {
+			order = append(order, i)
+			seen[i] = true
+		}
+	}
+	order = append(order, cooling...)
+	if len(order) > dialMaxAttempts {
+		order = order[:dialMaxAttempts]
+	}
+	out := make([]config.Endpoint, len(order))
+	for i, idx := range order {
+		out[i] = eps[idx]
+	}
+	return out
 }
 
-func (d *endpointDialer) dial() (*yamux.Session, string, error) {
-	ep := d.pick()
-	session, err := DialEndpoint(ep, d.node.AuthToken, d.cfg)
-	if err != nil {
-		slog.Warn("pipe dial failed", "node", d.node.Alias, "mimic", ep.Mimic, "target", ep.Target, "err", err)
-		return nil, ep.Mimic, err
+// weightedPick returns a weighted-random index from the candidate indices.
+func (d *endpointDialer) weightedPick(cand []int) int {
+	if len(cand) == 1 {
+		return cand[0]
 	}
-	slog.Info("pipe established", "node", d.node.Alias, "mimic", ep.Mimic, "target", ep.Target)
-	go keepAlive(session)
-	return session, ep.Mimic, nil
+	total := 0.0
+	for _, i := range cand {
+		total += d.weights[i]
+	}
+	r := mrand.Float64() * total
+	for _, i := range cand {
+		if r -= d.weights[i]; r <= 0 {
+			return i
+		}
+	}
+	return cand[len(cand)-1]
+}
+
+func (d *endpointDialer) recordSuccess(target string) {
+	d.mu.Lock()
+	if h := d.health[target]; h != nil {
+		h.fails, h.cooldownUntil = 0, time.Time{}
+	}
+	d.mu.Unlock()
+}
+
+func (d *endpointDialer) recordFailure(target string) {
+	d.mu.Lock()
+	h := d.health[target]
+	if h == nil {
+		h = &epHealth{}
+		d.health[target] = h
+	}
+	h.fails++
+	if h.fails >= epFailThreshold {
+		back := epCooldownBase << uint(h.fails-epFailThreshold)
+		if back <= 0 || back > epCooldownMax {
+			back = epCooldownMax
+		}
+		h.cooldownUntil = time.Now().Add(back)
+	}
+	d.mu.Unlock()
+}
+
+// dial establishes one physical pipe, racing across candidate ports so a censored
+// entry port does not stop the tunnel from coming up. The first port that completes
+// the mimic handshake wins; failures cool the port down so it is skipped next time.
+func (d *endpointDialer) dial() (*yamux.Session, string, error) {
+	var lastErr error
+	for _, ep := range d.attemptOrder() {
+		session, err := DialEndpoint(ep, d.node.AuthToken, d.cfg)
+		if err != nil {
+			d.recordFailure(ep.Target)
+			slog.Warn("pipe dial failed", "node", d.node.Alias, "mimic", ep.Mimic, "target", ep.Target, "err", err)
+			lastErr = err
+			continue
+		}
+		d.recordSuccess(ep.Target)
+		slog.Info("pipe established", "node", d.node.Alias, "mimic", ep.Mimic, "target", ep.Target)
+		go keepAlive(session)
+		return session, ep.Mimic, nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("node %q has no endpoints to dial", d.node.Alias)
+	}
+	return nil, "", lastErr
 }
 
 // keepAlive sends a randomized-interval Yamux ping to evade DPI periodicity checks.

--- a/internal/ingress/dial_test.go
+++ b/internal/ingress/dial_test.go
@@ -94,14 +94,14 @@ func TestProbeEndpointWrongToken(t *testing.T) {
 	}
 }
 
-// TestEndpointPickerAlwaysValid checks the Chaos-Mesh weighted picker: a single
-// endpoint is returned as-is, and with several endpoints every pick is a real
-// configured endpoint (weights are sane, no out-of-range index).
+// TestEndpointPickerAlwaysValid checks the Chaos-Mesh weighted primary pick (the
+// first entry of attemptOrder): a single endpoint is returned as-is, and with several
+// endpoints every primary pick is a real configured endpoint that appears over time.
 func TestEndpointPickerAlwaysValid(t *testing.T) {
 	single := config.ForeignNode{Endpoints: []config.Endpoint{{Target: "1.2.3.4:22", Mimic: "ssh"}}}
 	d := newEndpointDialer(single)
-	if got := d.pick(); got.Mimic != "ssh" {
-		t.Fatalf("single-endpoint pick = %+v", got)
+	if got := d.attemptOrder(); len(got) != 1 || got[0].Mimic != "ssh" {
+		t.Fatalf("single-endpoint order = %+v", got)
 	}
 
 	multi := config.ForeignNode{Endpoints: []config.Endpoint{
@@ -116,15 +116,13 @@ func TestEndpointPickerAlwaysValid(t *testing.T) {
 	valid := map[string]bool{"ssh": true, "tls": true, "imaps": true}
 	seen := map[string]int{}
 	for i := 0; i < 300; i++ {
-		ep := d.pick()
+		ep := d.attemptOrder()[0] // the weighted primary pick
 		if !valid[ep.Mimic] {
-			t.Fatalf("pick returned an unknown endpoint: %+v", ep)
+			t.Fatalf("primary pick returned an unknown endpoint: %+v", ep)
 		}
 		seen[ep.Mimic]++
 	}
-	// Over 300 weighted draws all three should appear at least once (weights are
-	// 0.3+rand, so none is ever zero).
 	if len(seen) != 3 {
-		t.Fatalf("expected all 3 endpoints to be picked, saw %v", seen)
+		t.Fatalf("expected all 3 endpoints to be primary-picked, saw %v", seen)
 	}
 }

--- a/internal/ingress/dialhealth_test.go
+++ b/internal/ingress/dialhealth_test.go
@@ -1,0 +1,111 @@
+package ingress
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hedioum/Hedioum-Pool-Tunnel/config"
+)
+
+func threeEndpointDialer() *endpointDialer {
+	return newEndpointDialer(config.ForeignNode{Alias: "N", Endpoints: []config.Endpoint{
+		{Target: "1.2.3.4:2200", Mimic: "ssh"},
+		{Target: "1.2.3.4:443", Mimic: "tls"},
+		{Target: "1.2.3.4:5432", Mimic: "postgres"},
+	}})
+}
+
+// TestAttemptOrderCapAndPrimary: the order starts with the weighted primary pick and
+// is capped at dialMaxAttempts, containing only real endpoints with no duplicates.
+func TestAttemptOrderCapAndPrimary(t *testing.T) {
+	d := newEndpointDialer(config.ForeignNode{Endpoints: []config.Endpoint{
+		{Target: "h:1", Mimic: "ssh"}, {Target: "h:2", Mimic: "tls"}, {Target: "h:3", Mimic: "smtp"},
+		{Target: "h:4", Mimic: "imap"}, {Target: "h:5", Mimic: "docker"}, {Target: "h:6", Mimic: "mysql"},
+	}})
+	order := d.attemptOrder()
+	if len(order) != dialMaxAttempts {
+		t.Fatalf("order len = %d, want cap %d", len(order), dialMaxAttempts)
+	}
+	seen := map[string]bool{}
+	for _, ep := range order {
+		if seen[ep.Target] {
+			t.Fatalf("duplicate endpoint in order: %v", ep.Target)
+		}
+		seen[ep.Target] = true
+	}
+}
+
+// TestCooledPortIsDeprioritized: with the ssh port cooled down (as if outbound :2200
+// is blocked), it is only tried after every reachable endpoint — so a censored entry
+// port never stalls the connect-race ahead of a working one.
+func TestCooledPortIsDeprioritized(t *testing.T) {
+	d := threeEndpointDialer()
+	d.recordFailure("1.2.3.4:2200") // block ssh
+	d.recordFailure("1.2.3.4:2200")
+
+	order := d.attemptOrder()
+	posTLS, posPG, posSSH := -1, -1, -1
+	for i, ep := range order {
+		switch ep.Mimic {
+		case "tls":
+			posTLS = i
+		case "postgres":
+			posPG = i
+		case "ssh":
+			posSSH = i
+		}
+	}
+	if posSSH == -1 {
+		return // ssh dropped past the cap entirely — even better
+	}
+	if posTLS != -1 && posSSH < posTLS || posPG != -1 && posSSH < posPG {
+		t.Fatalf("cooled-down ssh must come after reachable endpoints: %+v", order)
+	}
+}
+
+// TestDialRankInnocuousFirst: the fallback rank puts 443/8443 ahead of ssh and the
+// databases, so a partial outage falls back to the most-reachable ports first.
+func TestDialRankInnocuousFirst(t *testing.T) {
+	if dialRank("tls") >= dialRank("ssh") {
+		t.Fatal("tls must rank before ssh")
+	}
+	if dialRank("tls") >= dialRank("postgres") || dialRank("https-alt") >= dialRank("mysql") {
+		t.Fatal("443/8443 must rank before the databases")
+	}
+	if dialRank("ssh") < dialRank("mysql") {
+		t.Fatal("ssh (often blocked) should rank last, after the databases")
+	}
+}
+
+// TestCooldownAndRecovery: an endpoint is cooled down after the threshold, excluded
+// from the reachable set, and success clears it.
+func TestCooldownAndRecovery(t *testing.T) {
+	d := threeEndpointDialer()
+	tgt := "1.2.3.4:2200"
+
+	d.recordFailure(tgt) // 1 fail — not yet cooled
+	if d.health[tgt].cooldownUntil.After(time.Now()) {
+		t.Fatal("one failure should not cool down yet")
+	}
+	d.recordFailure(tgt) // 2 fails — cooled
+	if !d.health[tgt].cooldownUntil.After(time.Now()) {
+		t.Fatal("threshold failures should cool the endpoint down")
+	}
+	d.recordSuccess(tgt)
+	if d.health[tgt].fails != 0 || d.health[tgt].cooldownUntil.After(time.Now()) {
+		t.Fatal("success should clear the cooldown")
+	}
+}
+
+// TestAllCooledStillTried: when every endpoint is cooling down, attemptOrder still
+// returns candidates (the block may have lifted) rather than giving up.
+func TestAllCooledStillTried(t *testing.T) {
+	d := threeEndpointDialer()
+	for _, tgt := range []string{"1.2.3.4:2200", "1.2.3.4:443", "1.2.3.4:5432"} {
+		d.recordFailure(tgt)
+		d.recordFailure(tgt)
+	}
+	if got := d.attemptOrder(); len(got) == 0 {
+		t.Fatal("attemptOrder must still return candidates when all are cooled down")
+	}
+}


### PR DESCRIPTION
## Summary

A censored entry port no longer stalls the tunnel. The endpoint dialer now races each dial across candidate ports and remembers which ones are reachable.

- **Connect-race per dial:** a weighted-random primary pick (mimic diversity, Chaos Mesh) followed by the remaining reachable endpoints in innocuous-port-first order (443/8443 first, ssh last since it is the most commonly blocked). The first port that completes the handshake wins.
- **Reachability memory:** after `epFailThreshold` consecutive failures a port is cooled down (exponential backoff up to 10m) and skipped, so a blocked port stops wasting attempts; a success clears it, and cooled ports are retried once the cooldown lapses (the block may have lifted). If every port is cooled, it still tries them all. Attempts per dial are capped so a fully-down node fails fast.
- `tls` (:443) is in every persona, guaranteeing an always-reachable bootstrap path.

## Live validation (clean reinstall on both servers)

Full clean-slate run: uninstall + verify both servers → fresh reinstall → **paste-only** hub onboarding from a v2 token (directadmin persona, 10 endpoints) → probe 10/10, exit IP correct, censored sites 200, 223/237 Mbps.

Then the connect-race test: **`iptables`-DROP the ssh port (2200) on the hub, cold-restart → the tunnel still comes up** (exit IP correct, YouTube 200); logs show ssh failed once, was cooled down and skipped, and the pool built on docker/grafana/postgres/smtp/tls. Lifting the block → ssh reachable again.

Unit tests cover the attempt ordering/cap, cooled-port deprioritization, cooldown+recovery, and the all-cooled fallback.

## Milestone

M4 is the last of the persona/token/connect-race arc (M2→M3→M4). Per plan, the version now bumps to **v0.9.0** and is tagged/released.